### PR TITLE
Use HTTPS instead of SSH when downloading the git repo

### DIFF
--- a/binscripts/gvm-installer
+++ b/binscripts/gvm-installer
@@ -25,7 +25,7 @@ else
 	GVM_NAME="gvm"
 fi
 
-SRC_REPO=git://github.com/moovweb/gvm.git
+SRC_REPO=https://github.com/moovweb/gvm.git
 
 [ "$GVM_DEST" == "" ] && display_error "No destination specified!"
 [ -d $GVM_DEST/$GVM_NAME ] && display_error "Already installed!"


### PR DESCRIPTION
Some firewalls block port 9418 (the default of git+ssh)
