### PR TITLE
Provide support for FreeBSD.

### DIFF
--- a/README
+++ b/README
@@ -46,7 +46,7 @@ To completely remove gvm and all installed Go versions and packages:
 
 If that doesn't work see the troubleshooting steps at the bottom of this page.
 
-Mac OSX Requirements
+Mac OS X Requirements
 ====================
     Install mercurial from http://mercurial.berkwood.com/
 
@@ -59,6 +59,13 @@ Linux Requirements
     sudo apt-get install binutils
     sudo apt-get install bison
     sudo apt-get install gcc
+
+FreeBSD Requirements
+====================
+
+    sudo pkg_add -r bash
+    sudo pkg_add -r git
+    sudo pkg_add -r mercurial
 
 Troubleshooting
 ===============

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To completely remove gvm and all installed Go versions and packages:
 
     gvm implode
 
-Mac OSX Requirements
+Mac OS X Requirements
 ====================
     Install mercurial from http://mercurial.berkwood.com/
 
@@ -55,3 +55,11 @@ Linux Requirements
     sudo apt-get install binutils
     sudo apt-get install bison
     sudo apt-get install gcc
+
+FreeBSD Requirements
+====================
+
+    sudo pkg_add -r bash
+    sudo pkg_add -r git
+    sudo pkg_add -r mercurial
+

--- a/bin/gvm
+++ b/bin/gvm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ -z "$GVM_ROOT" ]; then
 	tput sgr0
 	tput setaf 1

--- a/bin/gvm-prompt
+++ b/bin/gvm-prompt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 function gvm_prompt() {
 	if [[ "$1" == "g" ]]; then
 		echo $gvm_go_name

--- a/binscripts/gvm-installer
+++ b/binscripts/gvm-installer
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 display_error() {
 	tput sgr0
 	tput setaf 1

--- a/scripts/alias
+++ b/scripts/alias
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 command=$1

--- a/scripts/alias-create
+++ b/scripts/alias-create
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 [[ $1 != "" ]] ||

--- a/scripts/alias-delete
+++ b/scripts/alias-delete
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 [[ $1 != "" ]] ||

--- a/scripts/alias-list
+++ b/scripts/alias-list
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 echo

--- a/scripts/cross
+++ b/scripts/cross
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 display_usage() {

--- a/scripts/diff
+++ b/scripts/diff
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 version=$1

--- a/scripts/env/gvm
+++ b/scripts/env/gvm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions || return 1
 
 function gvm() {

--- a/scripts/env/pkgset-use
+++ b/scripts/env/pkgset-use
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 function gvm_pkgset_use() {
 	[[ "$1" != "" ]] ||
 		display_error "Please specify a package set" || return 1

--- a/scripts/env/use
+++ b/scripts/env/use
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 function gvm_use() {
 	[[ "$1" != "" ]] ||
 		display_error "Please specifiy the version" || return 1

--- a/scripts/function/tools
+++ b/scripts/function/tools
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 LS_ERROR="GVM couldn't find ls"
 GREP_ERROR="GVM couldn't find grep"
 SORT_ERROR="GVM couldn't find sort"

--- a/scripts/functions
+++ b/scripts/functions
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 for function in $GVM_ROOT/scripts/function/*; do
 	. $function
 done

--- a/scripts/get
+++ b/scripts/get
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 [[ -d $GVM_ROOT/.git ]] || mv $GVM_ROOT/git.bak $GVM_ROOT/.git &> /dev/null ||

--- a/scripts/gvm-check
+++ b/scripts/gvm-check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 # Check for hg

--- a/scripts/install
+++ b/scripts/install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 function show_usage() {

--- a/scripts/list
+++ b/scripts/list
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 echo

--- a/scripts/listall
+++ b/scripts/listall
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 function show_usage() {

--- a/scripts/pkgset
+++ b/scripts/pkgset
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 [[ $gvm_go_name != "" ]] || 

--- a/scripts/pkgset-create
+++ b/scripts/pkgset-create
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 [[ $1 != "" ]] || 

--- a/scripts/pkgset-delete
+++ b/scripts/pkgset-delete
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 [[ $gvm_go_name != "" ]] || 

--- a/scripts/pkgset-empty
+++ b/scripts/pkgset-empty
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 [[ $gvm_pkgset_name != "" ]] ||

--- a/scripts/pkgset-list
+++ b/scripts/pkgset-list
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 echo

--- a/scripts/templates/binary
+++ b/scripts/templates/binary
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions/tools
 echo $1 | sed -n -e '/_.*_/ p' | $GREP_PATH "_" &> /dev/null
 if [ "$?" == "0" ]; then

--- a/scripts/uninstall
+++ b/scripts/uninstall
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 [[ "$1" == "" ]] && 

--- a/scripts/update
+++ b/scripts/update
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
 cd $GVM_ROOT/archive/go &> /dev/null ||

--- a/tests/gvm_version
+++ b/tests/gvm_version
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash -ex
 TEST_OUTPUT=`gvm version`
 [ "$TEST_OUTPUT" != "" ]
 echo "Success!"


### PR DESCRIPTION
FreeBSD does not by default install the Bourne-Again Shell (bash); and
when it is installed, it is most certainly not installed to
`/bin/bash` due to the nuances of the conventions around local site
packages.  Rather, it is installed to `/usr/local/bin/bash`.

Golang explicitly supports FreeBSD, so it should only be reasonable for
GVM to support this target, too.  As a fix, the shell script shebang
definitions now use the `env` tool that comes from the _coreutils_
standard package, which is installed on all conventions-adhering Linux
distributions, Mac OS X, and FreeBSD.

FreeBSD prerequisites are now listed in the documentation.

I have tested this against FreeBSD 9.0 release branch on the amd64,
and it works satisfactorily now.
