### PR TITLE
Store packageset data under local path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Features
 ========
 * Install/Uninstall Go versions with `gvm install [tag]` where tag is "60.3", "go1", "weekly.2011-11-08", or "tip"
 * List added/removed files in GOROOT with `gvm diff`
-* Manage GOPATHs with `gvm pkgset [create/use/delete] [name]`
+* Manage GOPATHs with `gvm pkgset [create/use/delete] [name]`. Use `--local` as `name` to manage repository under local path (`/path/to/repo/.gvm_local`).
 * List latest release tags with `gvm listall`. Use `--all` to list weekly as well.
 * Cache a clean copy of the latest Go source for multiple version installs.
 

--- a/scripts/env/pkgset-use
+++ b/scripts/env/pkgset-use
@@ -3,20 +3,42 @@ function gvm_pkgset_use() {
 	[[ "$1" != "" ]] ||
 		display_error "Please specify a package set" || return 1
 
-	[[ "$gvm_go_name" != "" ]] || 
+	[[ "$gvm_go_name" != "" ]] ||
 		display_error "No Go version selected" || return 1
 
-	fuzzy_match=`$LS_PATH $GVM_ROOT/environments | $SORT_PATH | $GREP_PATH "$gvm_go_name@" | $GREP_PATH "$1" | $HEAD_PATH -n 1` ||
-		display_error "Invalid package set" || return 1
+	if [[ "$1" == "--local" ]]; then
+		. $GVM_ROOT/scripts/function/find_local_pkgset
+		local LOCAL_TOP=$(find_local_pkgset)
+		unset -f find_local_pkgset
+		[[ -d $LOCAL_TOP ]] ||
+			display_error "Caonnt find local pakcage set" || return 1
+		LOCAL_TOP=$LOCAL_TOP/.gvm_local
 
-	export PATH=$GVM_PATH_BACKUP
-	. "$GVM_ROOT/environments/$fuzzy_match" ||
-		display_error "Failed to source the package set environment" || return 1
+		fuzzy_match=`$LS_PATH $LOCAL_TOP/environments | $SORT_PATH | $GREP_PATH "$gvm_go_name@" | $GREP_PATH "local" | $HEAD_PATH -n 1` ||
+			display_error "Cannot find local package set" || return 1
 
-	if [[ "$2" == "--default" ]]; then
-		cp $GVM_ROOT/environments/$fuzzy_match $GVM_ROOT/environments/default
+		[[ "$2" != "--default" ]] ||
+			display_error "Cannot set local pkgset as default" || return 1
+
+		export PATH=$GVM_PATH_BACKUP
+		. "$LOCAL_TOP/environments/$fuzzy_match" ||
+			display_error "Failed to source the package set environment" || return 1
+
+		echo "Now using version $gvm_go_name in local package set"
+		echo "Local GOPATH is now $LOCAL_TOP"
+	else
+		fuzzy_match=`$LS_PATH $GVM_ROOT/environments | $SORT_PATH | $GREP_PATH "$gvm_go_name@" | $GREP_PATH "$1" | $HEAD_PATH -n 1` ||
+			display_error "Invalid package set" || return 1
+
+		export PATH=$GVM_PATH_BACKUP
+		. "$GVM_ROOT/environments/$fuzzy_match" ||
+			display_error "Failed to source the package set environment" || return 1
+
+		if [[ "$2" == "--default" ]]; then
+			cp $GVM_ROOT/environments/$fuzzy_match $GVM_ROOT/environments/default
+		fi
+
+		echo "Now using version $fuzzy_match"
 	fi
-
-	echo "Now using version $fuzzy_match"
 }
 

--- a/scripts/function/find_local_pkgset
+++ b/scripts/function/find_local_pkgset
@@ -1,0 +1,19 @@
+function find_local_pkgset
+{
+    local TOPFILE=.gvm_local
+    if [ -d $TOPFILE ] ; then
+        PWD= /bin/pwd
+    else
+        local HERE=$PWD
+        T=
+        while [ \( ! \( -d $TOPFILE \) \) -a \( $PWD != "/" \) ]; do
+            \cd ..
+            T=`PWD= /bin/pwd`
+        done
+        \cd $HERE
+        if [ -d "$T/$TOPFILE" ]; then
+            echo $T
+        fi
+    fi
+}
+

--- a/scripts/pkgset-create
+++ b/scripts/pkgset-create
@@ -1,20 +1,42 @@
 #!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
-[[ $1 != "" ]] || 
+[[ $1 != "" ]] ||
 	display_fatal "Please specifiy the name"
 
-[[ ! -f "$GVM_ROOT/environments/$gvm_go_name@$1" ]] || 
+target_top=$GVM_ROOT
+target_set_name=$1
+target_set_name_str=$1
+add_gopath="$GVM_ROOT/pkgsets/$gvm_go_name/$1"
+add_path="$GVM_ROOT/pkgsets/$gvm_go_name/$1/bin"
+
+if [[ $1 == "--local" ]]; then
+	LOCAL_TOP=$(find_local_pkgset)
+	if [[ ! -d LOCAL_TOP ]]; then
+		LOCAL_TOP=$PWD
+	fi
+	target_top=$LOCAL_TOP/.gvm_local
+	target_set_name="local"
+	target_set_name_str="__local__"
+	add_gopath="$target_top/pkgsets/$gvm_go_name/$target_set_name"
+	add_gopath="$LOCAL_TOP:$add_gopath"
+	add_path="$target_top/pkgsets/$gvm_go_name/$target_set_name/bin"
+	add_path="$LOCAL_TOP/bin:$add_path"
+fi
+
+[[ ! -f "$target_top/environments/$gvm_go_name@$target_set_name" ]] ||
 	display_fatal "Packageset already exists!"
 
-mkdir -p $GVM_ROOT/pkgsets/$gvm_go_name/$1 ||
-	display_fatal "Could not create folder"
-cp $GVM_ROOT/environments/$gvm_go_name $GVM_ROOT/environments/$gvm_go_name@$1 ||
+mkdir -p $target_top/environments ||
+	display_fatal "Could not create environments folder"
+mkdir -p $target_top/pkgsets/$gvm_go_name/$target_set_name ||
+	display_fatal "Could not create packageset folder"
+cp $GVM_ROOT/environments/$gvm_go_name $target_top/environments/$gvm_go_name@$target_set_name ||
 	display_fatal "Could copy environment"
-echo "export gvm_pkgset_name=\"$1\"" >> $GVM_ROOT/environments/$gvm_go_name@$1 ||
+echo "export gvm_pkgset_name=\"$target_set_name_str\"" >> $target_top/environments/$gvm_go_name@$target_set_name ||
 	display_fatal "Could not extend environment"
-echo "export GOPATH; GOPATH=\"$GVM_ROOT/pkgsets/$gvm_go_name/$1:\$GOPATH\"" >> $GVM_ROOT/environments/$gvm_go_name@$1 ||
+echo "export GOPATH; GOPATH=\"$add_gopath:\$GOPATH\"" >> $target_top/environments/$gvm_go_name@$target_set_name ||
 	display_fatal "Could not extend environment"
-echo "export PATH; PATH=\"$GVM_ROOT/pkgsets/$gvm_go_name/$1/bin:\$PATH\"" >> $GVM_ROOT/environments/$gvm_go_name@$1 ||
+echo "export PATH; PATH=\"$add_path:\$PATH\"" >> $target_top/environments/$gvm_go_name@$target_set_name ||
 	display_fatal "Could not extend environment"
 

--- a/scripts/pkgset-delete
+++ b/scripts/pkgset-delete
@@ -1,18 +1,25 @@
 #!/usr/bin/env bash
 . $GVM_ROOT/scripts/functions
 
-[[ $gvm_go_name != "" ]] || 
+[[ $gvm_go_name != "" ]] ||
 	display_fatal "No Go version selected"
 
-[[ $1 != "" ]] || 
+[[ $1 != "" ]] ||
 	display_fatal "Please specifiy the name"
 
-[[ -d $GVM_ROOT/pkgsets/$gvm_go_name/$1 ]] || 
-	display_fatal "Packageset doesn't exist!"
+target_top=$GVM_ROOT
+target_set_name=$1
+if [[ $1 == "--local" ]]; then
+	target_top=$(find_local_pkgset)/.gvm_local
+	target_set_name="local"
+fi
 
-rm -rf $GVM_ROOT/pkgsets/$gvm_go_name/$1 ||
-	display_fatal "Could not delete package set"
+[[ -d $target_top/pkgsets/$gvm_go_name/$target_set_name ]] ||
+    display_fatal "Packageset doesn't exist!"
 
-rm -rf $GVM_ROOT/environments/$gvm_go_name@$1 ||
-	display_fatal "Could not delete package set"
+rm -rf $target_top/pkgsets/$gvm_go_name/$target_set_name ||
+    display_fatal "Could not delete package set"
+
+rm -rf $target_top/environments/$gvm_go_name@$target_set_name ||
+    display_fatal "Could not delete package set"
 

--- a/scripts/pkgset-list
+++ b/scripts/pkgset-list
@@ -6,13 +6,22 @@ display_message "gvm go package sets ($gvm_go_name)"
 echo
 
 if [[ -d $GVM_ROOT/pkgsets/$gvm_go_name ]]; then
+	pkgset_local=$(find_local_pkgset)
+	if [[ -d $pkgset_local ]]; then
+		if [[ "$gvm_pkgset_name" == "__local__" ]]; then
+			echo "=>L $pkgset_local"
+		else
+			echo "  L $pkgset_local"
+		fi
+	fi
+
 	for cur_dir in $GVM_ROOT/pkgsets/$gvm_go_name/*; do
 		[[ "$cur_dir" == "$GVM_ROOT/pkgsets/$gvm_go_name/*" ]] && exit
 		pkgset=`basename $cur_dir`
 		if [[ "$gvm_pkgset_name" == "$pkgset" ]]; then
-			echo "=> $pkgset"
+			echo "=>  $pkgset"
 		else
-			echo "   $pkgset"
+			echo "    $pkgset"
 		fi
 	done
 fi


### PR DESCRIPTION
Hi Josh,

I'm trying to make packageset more portalbe so that we can place our codebase everwhere. To my case, I have to manage at least two Go repository under different folders: one for job, and my own pet-projects. I love gvm, it it more powerful than Go's build-in import system, but I notice that I still have to change `$GOPATH` by my hands so that I could execute `go build <my_package>` under my repository.

In this patch, I add a new option while managing packagesets. While replacing pakcageset name with `--local`, the packageset information will be managed under `some/local/repo/.gvm_local` folder, and add the root path of repository as the first path in `GOPATH` and `PATH`. This makes the repository more portable since we don't store all the
go-installed package files under `$HOME/.gvm` .

The repository root path for gvm is definded as `$PWD` while `pkgset create --local`. When `pkgset list` under some configured local repository, it will list the root path as the first packageset, and marked with `L`.

Currently it store all the files under `.gvm_local`. Though we can easily share our packageset to another computer, it's a little disturbing to copy all the binary results. Maybe we could only export/import package list, just like what virtualenv (for Pythong) does.
