### PR TITLE
add -w option to grep

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -56,7 +56,7 @@ download_source() {
 }
 
 check_tag() {
-	version=`hg tags -R $GO_CACHE_PATH | awk '{print $1}' | $SORT_PATH | $GREP_PATH "$VERSION" | $HEAD_PATH -n 1 | $GREP_PATH "$VERSION"`
+	version=`hg tags -R $GO_CACHE_PATH | awk '{print $1}' | $SORT_PATH | $GREP_PATH "$VERSION" | $HEAD_PATH -n 1 | $GREP_PATH -w "$VERSION"`
 }
 
 update_source() {


### PR DESCRIPTION
I have a problem with installing go1.1.
Given the following result from hg tags, and trying to install go1.1 with "gvm install go1.1", check_tag function returns "go1.1rc2" and won't call update_source function.

```
tip                            16773:30c566874b83
go1.1rc3                       16772:5a15f0dae379
go1.1rc2                       16758:35da6063e57f
release                        13677:2d8bc3c94ecb
go1.0.3                        13677:2d8bc3c94ecb
go1.0.2                        13230:5e806355a9e1
go1.0.1                        12994:2ccfd4b451d3
go1                            12872:920e9d1ffd1f
weekly.2012-03-27              12869:dc5e410f0b4c
weekly                         12869:dc5e410f0b4c
weekly.2012-03-22              12804:bce220d03774
weekly.2012-03-13              12684:3cdba7b0650c
weekly.2012-03-04              12439:f4470a54e6db
weekly.2012-02-22              12235:96bd78e7d35e
weekly.2012-02-14              12000:43cf9b39b647
weekly.2012-02-07              11764:52ba9506bd99
weekly.2012-01-27              11507:1107a7d3cb07
weekly.2012-01-20              11362:9f2be4fbbf69
...
```

To install a correct version, I added a "-w" options to grep hg tags results.
