### PR TITLE
Allow for in-session changes to $PATH

### DIFF
--- a/scripts/env/pkgset-use
+++ b/scripts/env/pkgset-use
@@ -20,7 +20,7 @@ function gvm_pkgset_use() {
 		[[ "$2" != "--default" ]] ||
 			display_error "Cannot set local pkgset as default" || return 1
 
-		export PATH=$GVM_PATH_BACKUP
+		gvm_export_path
 		. "$LOCAL_TOP/environments/$fuzzy_match" ||
 			display_error "Failed to source the package set environment" || return 1
 
@@ -30,7 +30,7 @@ function gvm_pkgset_use() {
 		fuzzy_match=`$LS_PATH $GVM_ROOT/environments | $SORT_PATH | $GREP_PATH "$gvm_go_name@" | $GREP_PATH "$1" | $HEAD_PATH -n 1` ||
 			display_error "Invalid package set" || return 1
 
-		export PATH=$GVM_PATH_BACKUP
+		gvm_export_path
 		. "$GVM_ROOT/environments/$fuzzy_match" ||
 			display_error "Failed to source the package set environment" || return 1
 

--- a/scripts/env/use
+++ b/scripts/env/use
@@ -14,7 +14,7 @@ function gvm_use() {
 		fi
 	fi
 
-	export PATH=$GVM_PATH_BACKUP
+	gvm_export_path
 	. $GVM_ROOT/environments/$fuzzy_match &> /dev/null || display_error "Couldn't source environment" || return 1
 	if [[ "$2" == "--default" ]]; then
 		cp $GVM_ROOT/environments/$fuzzy_match $GVM_ROOT/environments/default || display_error "Couldn't make $fuzzy_match default"

--- a/scripts/function/gvm_export_path
+++ b/scripts/function/gvm_export_path
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+function gvm_export_path() {
+	export PATH="$GVM_ROOT/bin:`echo "$PATH" | tr ":" "\n" | grep -v '^$' | egrep -v "$GVM_ROOT/(pkgsets|gos|bin)" | tr "\n" ":" | sed 's/:*$//'`"
+	export GVM_PATH_BACKUP="$PATH"
+}
+


### PR DESCRIPTION
This change is intended to retain any changes made to `$PATH` between when the `$GVM_PATH_BACKUP` snapshot is taken and any subsequent `gvm use` invocations.  The resetting of `$PATH` is a behavior which has caused repeated confusion for myself and friends, and has recently become a source of pain on Travis, where changes to `$PATH` in the global env matrix are lost.  I realize I'm adding a wad of `tr` pipe nonsense, so I'm totally prepared to be shot down, at which point I'll try again (assuming there's feedback).
