### PR TITLE
making readmes consistent with eachother.

### DIFF
--- a/README
+++ b/README
@@ -7,7 +7,7 @@ Features
 ========
 * Install/Uninstall Go versions with `gvm install [tag]` where tag is "60.3", "go1", "weekly.2011-11-08", or "tip"
 * List added/removed files in GOROOT with `gvm diff`
-* Manage GOPATHs with `gvm pkgset [create/use/delete] [name]`
+* Manage GOPATHs with `gvm pkgset [create/use/delete] [name]`. Use `--local` as `name` to manage repository under local path (`/path/to/repo/.gvm_local`).
 * List latest release tags with `gvm listall`. Use `--all` to list weekly as well.
 * Cache a clean copy of the latest Go source for multiple version installs.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ To completely remove gvm and all installed Go versions and packages:
 
     gvm implode
 
+If that doesn't work see the troubleshooting steps at the bottom of this page.
+
 Mac OS X Requirements
 ====================
 Install mercurial from http://mercurial.berkwood.com/


### PR DESCRIPTION
We have two READMEs...one without an extension and one with the markdown extension.  Do we need both of them? Regardless, it seemed that they were slightly out of sync with each other.  This PR puts them in sync again.
