### PR TITLE
Fixes more broken zsh completion cases

### DIFF
--- a/scripts/completion
+++ b/scripts/completion
@@ -15,7 +15,7 @@ _gvm()
 				use|delete|empty)
 					[[ "$gvm_go_name" == "" ]] && return 1
 					[[ $COMP_CWORD > 3 ]] && return 1
-					local version=$(for x in `$LS_PATH $GVM_ROOT/pkgsets/$gvm_go_name`; do echo ${x} ; done )
+					local version="$(for x in `$LS_PATH $GVM_ROOT/pkgsets/$gvm_go_name`; do echo ${x} ; done )"
 					COMPREPLY=( $(compgen -W "${version}" -- ${cur}) )
 					return 0
 				;;
@@ -35,11 +35,11 @@ _gvm()
 					[[ "$gvm_go_name" == "" ]] && return 1
 					[[ "$gvm_pkgset_name" == "" ]] && return 1
 					if [[ "$COMP_CWORD" == "3" ]]; then
-						local version=$(for x in `$LS_PATH $GVM_ROOT/pkgsets/$gvm_go_name/$gvm_pkgset_name/pkg.gvm`; do echo ${x} ; done )
+						local version="$(for x in `$LS_PATH $GVM_ROOT/pkgsets/$gvm_go_name/$gvm_pkgset_name/pkg.gvm`; do echo ${x} ; done )"
 						COMPREPLY=( $(compgen -W "${version}" -- ${cur}) )
 						return 0
 					elif [[ "$COMP_CWORD" == "4" ]]; then
-						local version=$(for x in `$LS_PATH $GVM_ROOT/pkgsets/$gvm_go_name/$gvm_pkgset_name/pkg.gvm/${COMP_WORDS[3]}`; do echo ${x} ; done )
+						local version="$(for x in `$LS_PATH $GVM_ROOT/pkgsets/$gvm_go_name/$gvm_pkgset_name/pkg.gvm/${COMP_WORDS[3]}`; do echo ${x} ; done )"
 						COMPREPLY=( $(compgen -W "${version}" -- ${cur}) )
 						return 0
 					fi
@@ -58,7 +58,7 @@ _gvm()
 		install)
 			[ ! -d $GVM_ROOT/archive/go ] && return 1
 			[[ $COMP_CWORD > 2 ]] && return 1
-			local version=$(for x in `hg tags -R $GVM_ROOT/archive/go | awk '{print $1}' | $GREP_PATH -E "release|tip"`; do echo ${x} ; done )
+			local version="$(for x in `hg tags -R $GVM_ROOT/archive/go | awk '{print $1}' | $GREP_PATH -E "release|tip"`; do echo ${x} ; done )"
 			COMPREPLY=( $(compgen -W "${version}" -- ${cur}) )
 			return 0
 		;;


### PR DESCRIPTION
There were more instances where the version parameter should be
quoted in zsh.

(Builds on previous PR #25: 45a4d1ff42820ed06b3fe0d5c56428dc2508d348 )
