### PR TITLE
Use ./all.bash instead of ./make.bash for race enabled packages.

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -77,8 +77,8 @@ compile_go() {
 	export GOBIN=$GO_INSTALL_ROOT/bin &&
 	export PATH=$GOBIN:$PATH &&
 	export GOROOT=$GO_INSTALL_ROOT &&
-	#cd $GO_INSTALL_ROOT/src && ./all.bash &> $GVM_ROOT/logs/go-$GO_NAME-compile.log ||
-	cd $GO_INSTALL_ROOT/src && ./make.bash &> $GVM_ROOT/logs/go-$GO_NAME-compile.log ||
+	# cd $GO_INSTALL_ROOT/src && ./make.bash &> $GVM_ROOT/logs/go-$GO_NAME-compile.log ||
+	cd $GO_INSTALL_ROOT/src && ./all.bash &> $GVM_ROOT/logs/go-$GO_NAME-compile.log ||
 		(rm -rf $GO_INSTALL_ROOT && display_fatal "Failed to compile")
 }
 


### PR DESCRIPTION
Using the gvm installed tip and attempting to run `go test -race` produces an error that looks like the following:

_testmain.go:5: can't find import: "regexp"

This issue is documented [here](https://code.google.com/p/go/issues/detail?id=6479). The proposed solution is to use ./all.bash when building from source to install race enabled library packages.
