### PR TITLE
Added build-essential to the Linux requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Linux Requirements
     sudo apt-get install binutils
     sudo apt-get install bison
     sudo apt-get install gcc
+    sudo apt-get install build-essential
 
 FreeBSD Requirements
 ====================


### PR DESCRIPTION
A friend of mine was trying to install go1.2 on his Ubuntu machine, and the compiler complained about a `unistd.h` file not being found. The problem was solved by installing `build-essential`.

Hence, why I propose that we add `build-essential` as a Linux requirement. I'm certain a lot of people will be spared the trouble of trying to figure out where the error is coming from.
