### PR TITLE
Make gvm pkgenv sensitive to the EDITOR environment variable

### DIFF
--- a/scripts/pkgenv
+++ b/scripts/pkgenv
@@ -33,4 +33,4 @@ fi
 
 env_file=$GVM_ROOT/environments/$gvm_go_name$gvm_env
 
-vi $env_file
+$(printenv EDITOR || echo 'vi') $env_file


### PR DESCRIPTION
For those who do not use 'vi', although 'vi' is still the default.
