### PR TITLE
Use "$PATH" to avoid weirdness.

### DIFF
--- a/scripts/gvm-default
+++ b/scripts/gvm-default
@@ -14,8 +14,8 @@ mkdir -p $GVM_ROOT/archive/package > /dev/null 2>&1
 mkdir -p $GVM_ROOT/environments > /dev/null 2>&1
 
 export GVM_VERSION=`cat $GVM_ROOT/VERSION`
-export PATH=$GVM_ROOT/bin:$PATH
-export GVM_PATH_BACKUP=$PATH
+export PATH="$GVM_ROOT/bin:$PATH"
+export GVM_PATH_BACKUP="$PATH"
 [ -f $GVM_ROOT/environments/default ] && . $GVM_ROOT/environments/default
 . $GVM_ROOT/scripts/env/gvm
 


### PR DESCRIPTION
Without this, I get this error when gvm is being loaded:

```
/home/manveru/.gvm/scripts/gvm-default:export:17: not an identifier: 2:/home/manveru/node_modules/.bin:/home/manveru/github/akunspy/gopbuf/bin:./node_modules/.bin:.
```
