### PR TITLE
fix binary download path to golang.org/dl

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -170,17 +170,24 @@ download_binary() {
 	fi
 
 	GO_BINARY_FILE=${VERSION}.${GVM_OS}-${GVM_ARCH}${GVM_OS_VERSION}.tar.gz
-	GO_BINARY_URL="https://go.googlecode.com/files/go${GO_BINARY_FILE}"
+	GO_BINARY_URL="http://golang.org/dl/go${GO_BINARY_FILE}"
 	GO_BINARY_PATH=${GVM_ROOT}/archive/${GO_BINARY_FILE}
 
 	if [ ! -f $GO_BINARY_PATH ]; then
 		curl -s -f -L $GO_BINARY_URL > ${GO_BINARY_PATH}
 
 		if [[ $? -ne 0 ]]; then
-			display_error "Failed to download binary go"
-			rm -rf $GO_INSTALL_ROOT
-			rm -f $GO_BINARY_PATH
-			exit 1
+			display_error "Failed to download binary go from http://golang.org. Trying https://go.googlecode.com"
+            		GO_BINARY_URL="https://go.googlecode.com/files/go${GO_BINARY_FILE}"
+
+            		curl -s -f -L $GO_BINARY_URL > ${GO_BINARY_PATH}
+
+            		if [[ $? -ne 0 ]]; then
+                		display_error "Failed to download binary go"
+                		rm -rf $GO_INSTALL_ROOT
+                		rm -f $GO_BINARY_PATH
+                		exit 1
+            		fi
 		fi
 	fi
 


### PR DESCRIPTION
https://storage.googleapis.com/golang/ doesn't seem to work anymore.

First try http://golang.org/dl/ where newer versions are. If it fails try google code for an older version.
