### PR TITLE
Update "gvm cross" to support ARM properly

### DIFF
--- a/scripts/cross
+++ b/scripts/cross
@@ -4,7 +4,7 @@
 display_usage() {
 	display_message "Usage: gvm cross [os] [arch]"
 	display_message "  os   = linux/darwin/windows"
-	display_message "  arch = amd64/386 (arm unsupported)"
+	display_message "  arch = amd64/386/arm"
 }
 
 display_list() {
@@ -25,9 +25,9 @@ which go &> /dev/null || display_fatal "Only available in versions after Go 1"
 [ -z "$1" ] && display_list
 
 if [ ! -f "$GOROOT/pkg/tool/cross" ]; then
-	display_message "Installing x86 and x86-64 commands"
+	display_message "Installing x86, x86-64, and ARM commands"
 	set -e
-	for arch in 8 6; do
+	for arch in 8 6 5; do
 		    for cmd in a c g l; do
 		            go tool dist install -v cmd/$arch$cmd ||
 						display_fatal "Couldn't compile tool: $arch$cmd"


### PR DESCRIPTION
Turns out we just needed to build the ARM compiler and it works:

``` console
$ gvm cross linux arm
Installing x86, x86-64, and ARM commands
cmd/8a
cmd/8c
cmd/8g
cmd/8l
cmd/6a
cmd/6c
cmd/6g
cmd/6l
cmd/5a
cmd/5c
cmd/5g
cmd/5l
Installing linux arm runtime library
pkg/runtime (linux/arm)
runtime
errors
sync/atomic
unicode
unicode/utf8
math
sort
encoding
unicode/utf16
crypto/subtle
container/list
container/ring
image/color
sync
runtime/race
container/heap
image/color/palette
io
syscall
hash
crypto/cipher
hash/crc32
crypto/hmac
hash/adler32
hash/crc64
hash/fnv
bytes
strings
text/tabwriter
bufio
path
html
time
compress/bzip2
strconv
math/rand
math/cmplx
os
crypto
reflect
encoding/base64
regexp/syntax
net/url
crypto/aes
crypto/rc4
crypto/md5
crypto/sha1
crypto/sha256
encoding/pem
crypto/sha512
encoding/ascii85
encoding/base32
image
path/filepath
os/exec
net
os/signal
io/ioutil
regexp
image/draw
image/jpeg
encoding/binary
fmt
debug/dwarf
crypto/des
index/suffixarray
flag
go/token
encoding/json
encoding/xml
text/template/parse
log
debug/elf
debug/macho
debug/pe
go/scanner
compress/flate
math/big
go/ast
text/template
encoding/hex
mime
net/textproto
runtime/pprof
cmd/yacc
compress/gzip
archive/tar
archive/zip
compress/lzw
compress/zlib
crypto/elliptic
crypto/rand
crypto/dsa
encoding/asn1
crypto/rsa
mime/multipart
database/sql/driver
debug/gosym
go/parser
go/printer
go/doc
database/sql
crypto/x509/pkix
encoding/csv
crypto/ecdsa
encoding/gob
html/template
crypto/x509
image/gif
image/png
go/build
cmd/cgo
go/format
cmd/fix
cmd/gofmt
crypto/tls
log/syslog
net/mail
os/user
runtime/debug
testing
testing/iotest
testing/quick
text/scanner
net/http
net/smtp
cmd/go
expvar
net/http/cgi
net/http/cookiejar
net/http/httptest
net/http/httputil
net/http/pprof
net/rpc
net/http/fcgi
net/rpc/jsonrpc
```
