### PR TITLE
Put in fix for when which command returns extra information

### DIFF
--- a/scripts/function/tools
+++ b/scripts/function/tools
@@ -9,3 +9,7 @@ GREP_PATH=$(unalias grep &> /dev/null; which grep) || display_error "$GREP_ERROR
 SORT_PATH=$(unalias sort &> /dev/null; which sort) || display_error "$SORT_ERROR" || return 1
 HEAD_PATH=$(unalias head &> /dev/null; which head) || display_error "$HEAD_ERROR" || return 1
 
+LS_PATH=${LS_PATH:$(expr index $LS_PATH '/')-1}
+GREP_PATH=${GREP_PATH:$(expr index $GREP_PATH '/')-1}
+SORT_PATH=${SORT_PATH:$(expr index $SORT_PATH '/')-1}
+HEAD_PATH=${HEAD_PATH:$(expr index $HEAD_PATH '/')-1}


### PR DESCRIPTION
I was having problems using GVM on my local machine.  I'm using zsh running on Arch Linux.  The issue was that the which command outputs some human-readable information before the path.  So the which output on my machine looks like this:

sort is /usr/bin/sort

I'm not sure if this is the best way to patch this issue, or if it deserves a patch at all, but this is how I was able to resolve the issue on my machine. 
