### PR TITLE
Added support for (now optional) missing GOROOT env variable

### DIFF
--- a/scripts/cross
+++ b/scripts/cross
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 . "$GVM_ROOT/scripts/functions"
 
+setup_goroot_path
+
 display_usage() {
 	display_message "Usage: gvm cross [os] [arch]"
 	display_message "  os   = linux/darwin/windows"

--- a/scripts/function/goroot_export_path
+++ b/scripts/function/goroot_export_path
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+function setup_goroot_path() {
+        # Check if it's not already defined
+        if [ -z "$GOROOT" ]; then
+    	    export GOROOT=`go env GOROOT`
+        fi
+}
+


### PR DESCRIPTION
GOROOT environment variable is now being more and more obsoleted, as you can get the root base (from compilation time) using `go env GOROOT`, I added code to detect if we're in such environment without totally removing the use of `$GOROOT` (may be used in some really rare & special cases).
