### PR TITLE
Fix "gvm cross" for Go 1.4

### DIFF
--- a/scripts/cross
+++ b/scripts/cross
@@ -28,10 +28,10 @@ if [ ! -f "$GOROOT/pkg/tool/cross" ]; then
 	display_message "Installing x86, x86-64, and ARM commands"
 	set -e
 	for arch in 8 6 5; do
-		    for cmd in a c g l; do
-		            go tool dist install -v cmd/$arch$cmd ||
-						display_fatal "Couldn't compile tool: $arch$cmd"
-		    done
+		for cmd in a c g l; do
+			go tool dist install -v cmd/$arch$cmd ||
+				display_fatal "Couldn't compile tool: $arch$cmd"
+		done
 	done
 	touch "$GOROOT/pkg/tool/cross"
 fi
@@ -44,7 +44,7 @@ export GOARCH=$1
 if [ ! -d "$GOROOT/pkg/${GOOS}_${GOARCH}" ]; then
 	display_message "Installing $GOOS $GOARCH runtime library"
 	if [ "$GOOS" = "windows" ]; then
-		    export CGO_ENABLED=0
+		export CGO_ENABLED=0
 	fi
 
 	cd "$GOROOT/src"

--- a/scripts/cross
+++ b/scripts/cross
@@ -48,7 +48,13 @@ if [ ! -d "$GOROOT/pkg/${GOOS}_${GOARCH}" ]; then
 	fi
 
 	cd "$GOROOT/src"
-	go tool dist install -v pkg/runtime ||
+	if [ -d pkg/runtime ]; then
+		runtime='pkg/runtime'
+	else
+		# Go 1.4 moved pkg/ up a level
+		runtime='runtime'
+	fi
+	go tool dist install -v "$runtime" ||
 		display_fatal "Couldn't compile runtime library for $GOOS $GOARCH"
 	go install -v -a std ||
 		display_fatal "Install runtime library for $GOOS $GOARCH"


### PR DESCRIPTION
> go tool dist: opendir /home/user/.gvm/gos/go1.4/src/pkg/runtime: No such file or directory
> ERROR: Couldn't compile runtime library for darwin amd64

I also took the liberty of including a second commit which fixes some whitespace inconsistencies in the same file (but I'm happy to remove/separate that commit if preferred).