### PR TITLE
Add check for curl dependency

### DIFF
--- a/scripts/gvm-check
+++ b/scripts/gvm-check
@@ -39,6 +39,14 @@ Could not find make
 
   linux: apt-get install make
 "
+# Check for curl
+which curl &> /dev/null ||
+	error_message="${error_message}
+Could not find curl
+
+  linux: apt-get install curl
+  mac:   brew install curl
+"
 
 if [ -n "$error_message" ]; then
 	display_warning "$error_message"


### PR DESCRIPTION
As a Ubuntu user I'd like to have a check for curl bin because it's not installed by default