### PR TITLE
Fix download for older go binary version

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -181,8 +181,8 @@ download_binary() {
 		curl -s -f -L $GO_BINARY_URL > ${GO_BINARY_PATH}
 
 		if [[ $? -ne 0 ]]; then
-			display_error "Failed to download binary go from http://golang.org. Trying https://storage.googleapis.com"
-			GO_BINARY_URL="https://storage.googleapis.com/golang/${GO_BINARY_FILE}"
+			display_error "Failed to download binary go from http://golang.org. Trying https://go.googlecode.com"
+			GO_BINARY_URL="https://go.googlecode.com/files/${GO_BINARY_FILE}"
 
 			curl -s -f -L $GO_BINARY_URL > ${GO_BINARY_PATH}
 


### PR DESCRIPTION
Fallback url to download older go binary isn't working anymore. Instead, older releases are hosted on go.googlecode.com. This PR fix the fallback url as well as fixing tests that were failing because of this.