### PR TITLE
Change Go source repository to git

### DIFF
--- a/scripts/completion
+++ b/scripts/completion
@@ -58,7 +58,7 @@ _gvm()
 		install)
 			[ ! -d $GVM_ROOT/archive/go ] && return 1
 			[[ $COMP_CWORD > 2 ]] && return 1
-			local version="$(for x in `hg tags -R $GVM_ROOT/archive/go | awk '{print $1}' | $GREP_PATH -E "release|tip|go"`; do echo ${x} ; done )"
+			local version="$(cd $GVM_ROOT/archive/go && for x in `git tag | $GREP_PATH -E "release|tip|go"`; do echo ${x} ; done )"
 			COMPREPLY=( $(compgen -W "${version}" -- ${cur}) )
 			return 0
 		;;

--- a/scripts/env/use
+++ b/scripts/env/use
@@ -6,7 +6,7 @@ function gvm_use() {
   fuzzy_match=$($LS_PATH "$GVM_ROOT/gos" | $SORT_PATH | $GREP_PATH "$1" | $HEAD_PATH -n 1 | $GREP_PATH "$1")
 	if [[ "$?" != "0" ]]; then
 		GO_CACHE_PATH=$GVM_ROOT/archive/go
-    version=$(hg tags -R "$GO_CACHE_PATH" | awk '{print $1}' | $SORT_PATH | $GREP_PATH "$VERSION" | $HEAD_PATH -n 1 | $GREP_PATH "$VERSION")
+    version=$(cd "$GO_CACHE_PATH" && git tag -l "$VERSION")
 		if [[ "x$version" == "x" ]]; then
 			display_error "Version not found locally. Try 'gvm install $1'" || return 1
 		else

--- a/scripts/gvm-check
+++ b/scripts/gvm-check
@@ -3,10 +3,10 @@
 
 error_message=""
 
-# Check for hg
-which hg &> /dev/null ||
+# Check for git
+which git &> /dev/null ||
 	error_message="${error_message}
-Could not find mercurial
+Could not find git
 
   linux: apt-get install mercurial
   mac:   brew install mercurial

--- a/scripts/install
+++ b/scripts/install
@@ -64,7 +64,7 @@ download_source() {
 }
 
 check_tag() {
-    version=$(cd "$GO_CACHE_PATH" && git tag -l "$VERSION")
+    version=$(cd "$GO_CACHE_PATH" && git show-ref --heads --tags | awk -F/ '{ print $NF }' | $SORT_PATH | $GREP_PATH "$VERSION" | $HEAD_PATH -n 1 | $GREP_PATH -w "$VERSION")
 }
 
 update_source() {

--- a/scripts/install
+++ b/scripts/install
@@ -21,7 +21,7 @@ read_command_line() {
 		show_usage
 		exit 1
 	fi
-	GO_SOURCE_URL=https://go.googlecode.com/hg/
+	GO_SOURCE_URL=https://go.googlesource.com/go
 	for i in "$@"; do
 		case $i in
 			-s=*|--source=*)
@@ -59,22 +59,22 @@ download_source() {
 	GO_CACHE_PATH=$GVM_ROOT/archive/go
 	[[ -d $GO_CACHE_PATH ]] && return
 	display_message "Downloading Go source..."
-	hg clone "$GO_SOURCE_URL" "$GO_CACHE_PATH" >> "$GVM_ROOT/logs/go-download.log"  2>&1 ||
+	git clone "$GO_SOURCE_URL" "$GO_CACHE_PATH" >> "$GVM_ROOT/logs/go-download.log"  2>&1 ||
 		display_fatal "Couldn't download Go source. Check the logs $GVM_ROOT/logs/go-download.log"
 }
 
 check_tag() {
-	version=$(hg tags -R "$GO_CACHE_PATH" | awk '{print $1}' | $SORT_PATH | $GREP_PATH "$VERSION" | $HEAD_PATH -n 1 | $GREP_PATH -w "$VERSION")
+    version=$(cd "$GO_CACHE_PATH" && git tag -l "$VERSION")
 }
 
 update_source() {
 	display_message "Updating Go source..."
-	hg pull -R "$GO_CACHE_PATH" >> "$GVM_ROOT/logs/go-download.log" 2>&1 ||
-		display_fatal "Couldn't get latest Go version info. Check the logs $GVM_ROOT/logs/go-download.log"
+	(cd "$GO_CACHE_PATH" && git pull >> "$GVM_ROOT/logs/go-download.log" 2>&1 ||
+		display_fatal "Couldn't get latest Go version info. Check the logs $GVM_ROOT/logs/go-download.log")
 }
 
 copy_source() {
-	hg clone -u "$version" "$GO_CACHE_PATH" "$GO_INSTALL_ROOT" >> "$GVM_ROOT/logs/go-$GO_NAME-install.log" 2>&1 ||
+	git clone -b "$version" "$GO_CACHE_PATH" "$GO_INSTALL_ROOT" >> "$GVM_ROOT/logs/go-$GO_NAME-install.log" 2>&1 ||
 		display_fatal "Couldn't copy source to target folder. Check the logs $GVM_ROOT/logs/go-$GO_NAME-install.log"
 }
 
@@ -285,7 +285,7 @@ install_from_source() {
 	which goinstall &> /dev/null ||
 		GVM_GOINSTALL="go get"
 
-	x="$(hg tags -R "$GO_CACHE_PATH")"; echo "${x#*b0819469a6df}" | $GREP_PATH "$version " &> /dev/null
+	x="$(cd "$GO_CACHE_PATH" && git tag)"; echo "${x#*b0819469a6df}" | $GREP_PATH "$version " &> /dev/null
 	if [[ "$?" == "1" ]]; then
 		if [[ "$INSTALL_BUILD_TOOLS" == "true" ]]; then
 			install_gb || display_warning "Failed to install gb"

--- a/scripts/listall
+++ b/scripts/listall
@@ -32,7 +32,7 @@ read_command_line "$@"
 echo
 display_message "gvm gos (available)"
 echo
-versions=$(curl -s https://go.googlecode.com/hg/.hgtags | awk '{ print $2 }' | $SORT_PATH)
+versions=$(git ls-remote -t https://go.googlesource.com/go | awk -F/ '{ print $NF }' | $SORT_PATH)
 if [[ $? -ne 0 ]]; then
 	display_fatal "Failed to get version list from Google"
 fi

--- a/scripts/update
+++ b/scripts/update
@@ -4,5 +4,5 @@
 cd "$GVM_ROOT/archive/go" &> /dev/null ||
 	display_fatal "Failed to find local Go source"
 
-hg pull || display_fatal "Failed to update"
+git pull || display_fatal "Failed to update"
 

--- a/tests/00gvm_install_comment_test.sh
+++ b/tests/00gvm_install_comment_test.sh
@@ -1,11 +1,13 @@
 ## Cleanup test objects
-gvm uninstall tip > /dev/null 2>&1
+gvm uninstall go1.4 > /dev/null 2>&1
+gvm uninstall master > /dev/null 2>&1
 gvm uninstall go1.1.1 > /dev/null 2>&1
 gvm uninstall go1.2.2 > /dev/null 2>&1
 #######################
 
-gvm install tip #status=0
-gvm list #status=0; match=/tip/
+gvm install go1.4 #status=0
+GOROOT_BOOTSTRAP=$GVM_ROOT/gos/go1.4 gvm install master #status=0
+gvm list #status=0; match=/master/
 gvm install go1.1.1 #status=0
 gvm list #status=0; match=/go1.1.1/
 gvm install go1.2.2   #status=0


### PR DESCRIPTION
Currently, the official Go source repository moved to [Git repository](https://go.googlesource.com/go).
An installation of newest Go version from source by `gvm install go1.4.1` doesn't work now because use the old Mercurial repository.