### PR TITLE
Fix profile source check during install

### DIFF
--- a/binscripts/gvm-installer
+++ b/binscripts/gvm-installer
@@ -11,9 +11,12 @@ display_error() {
 update_profile() {
 	[ -f "$1" ] || return 1
 
-	grep "$source_line" "$1" > /dev/null 2>&1
+	grep "${source_line//\$HOME/.*}" "$1" > /dev/null 2>&1
 	if [ $? -ne 0 ]; then
 		echo "$source_line" >> "$1"
+		echo "Added GVM source line to $1"
+	else
+		echo "GVM is already sourced in $1"
 	fi
 }
 

--- a/binscripts/gvm-installer
+++ b/binscripts/gvm-installer
@@ -92,7 +92,7 @@ popd > /dev/null
 
 [ -z "$GVM_NO_GIT_BAK" ] && mv "$GVM_DEST/$GVM_NAME/.git" "$GVM_DEST/$GVM_NAME/git.bak"
 
-source_line="[[ -s \"${GVM_DEST}/$GVM_NAME/scripts/gvm\" ]] && source \"${GVM_DEST}/$GVM_NAME/scripts/gvm\""
+source_line="[[ -s \"\$HOME/$GVM_NAME/scripts/gvm\" ]] && source \"\$HOME/$GVM_NAME/scripts/gvm\""
 source_file="${GVM_DEST}/$GVM_NAME/scripts/gvm"
 
 if [ -z "$GVM_NO_UPDATE_PROFILE" ] ; then


### PR DESCRIPTION
Since `$GVM_DEST` was expanding `$HOME`, reusing .bashrc on multiple machines (and reinstalling gvm) results in gvm adding multiple `$source_line`s.  This PR uses `$HOME` in the source line and adds a notification if gvm is already sourced.
