### PR TITLE
Respond to help command by showing usage info

### DIFF
--- a/bin/gvm
+++ b/bin/gvm
@@ -34,9 +34,7 @@ else
 	if [ -f "$GVM_ROOT/scripts/$command" ]; then
 		shift
 		"$GVM_ROOT/scripts/$command" "$@"
-	elif [[ -n $command ]]; then
-		display_fatal "Unrecognized command line argument: '$command'"
-	else
+	elif [[ -z $command || $command = help ]]; then
 		echo "Usage: gvm [command]
 
 Description:
@@ -47,6 +45,7 @@ Commands:
   get        - gets the latest code (for debugging)
   use        - select a go version to use
   diff       - view changes to Go root
+  help       - display this usage text
   implode    - completely remove gvm
   install    - install go versions
   uninstall  - uninstall go versions
@@ -58,5 +57,7 @@ Commands:
   pkgset     - manage go packages sets
   pkgenv     - edit the environment for a package set
 "
+	else
+		display_fatal "Unrecognized command line argument: '$command'"
 	fi
 fi


### PR DESCRIPTION
Has `gvm` respond politely to requests for help.

Before:

```console
maciek@mothra:~$ gvm help
ERROR: Unrecognized command line argument: 'help'
```

After:

```console
maciek@mothra:~$ gvm help
Usage: gvm [command]

Description:
  GVM is the Go Version Manager

Commands:
  version    - print the gvm version number
  get        - gets the latest code (for debugging)
  use        - select a go version to use
  diff       - view changes to Go root
  help       - display this usage text
  implode    - completely remove gvm
  install    - install go versions
  uninstall  - uninstall go versions
  cross      - install go cross compilers
  linkthis   - link this directory into GOPATH
  list       - list installed go versions
  listall    - list available versions
  alias      - manage go version aliases
  pkgset     - manage go packages sets
  pkgenv     - edit the environment for a package set
```

P.S.: thanks for gvm; it's neat!