### PR TITLE
Minor improvement: Adds go name to the compiled version if not provided by a golang release

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -85,6 +85,7 @@ compile_go() {
 	export GOBIN=$GO_INSTALL_ROOT/bin &&
 	export PATH=$GOBIN:$PATH &&
 	export GOROOT=$GO_INSTALL_ROOT &&
+	if [ ! -f "$GO_INSTALL_ROOT/VERSION" ]; then echo "$GO_NAME" > "$GO_INSTALL_ROOT/VERSION"; fi &&
 	#cd $GO_INSTALL_ROOT/src && ./all.bash &> $GVM_ROOT/logs/go-$GO_NAME-compile.log ||
 	cd "$GO_INSTALL_ROOT/src" && ./make.bash &> "$GVM_ROOT/logs/go-$GO_NAME-compile.log" ||
 		(rm -rf "$GO_INSTALL_ROOT" && display_fatal "Failed to compile. Check the logs at $GVM_ROOT/logs/go-$GO_NAME-compile.log")


### PR DESCRIPTION
If a git tag was checked out the compiled go does not contain a readable version information.

Compilation of go1.5beta3 will return:
```bash
gvm install go1.5beta3
gvm use go1.5beta3
go version
>go version devel +d3ffc97 Wed Jul 29 23:50:20 2015 +0000 linux/amd64
```

With this fix it will use the GO_NAME as version string
```bash
go version
>go version go1.5beta3 linux/amd64
```