### PR TITLE
Fix compilation problem of go1.5

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -81,6 +81,7 @@ copy_source() {
 
 compile_go() {
 	display_message " * Compiling..."
+	[ -z "$GOROOT_BOOTSTRAP" ] && export GOROOT_BOOTSTRAP=$GOROOT
 	unset GOARCH && unset GOOS && unset GOPATH && unset GOBIN && unset GOROOT &&
 	export GOBIN=$GO_INSTALL_ROOT/bin &&
 	export PATH=$GOBIN:$PATH &&


### PR DESCRIPTION
Go environment is required compilation of go1.5.
Bootstrap go can specify `GOROOT_BOOTSTRAP` environment variable, but default value is `$HOME/go1.4.`
