### PR TITLE
scripts: use real grep while building the PATH

### DIFF
--- a/scripts/function/gvm_export_path
+++ b/scripts/function/gvm_export_path
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 function gvm_export_path() {
-	export PATH="$GVM_ROOT/bin:$(echo "$PATH" | tr ":" "\n" | grep -v '^$' | egrep -v "$GVM_ROOT/(pkgsets|gos|bin)" | tr "\n" ":" | sed 's/:*$//')"
+	export PATH="$GVM_ROOT/bin:$(echo "$PATH" | tr ":" "\n" | "$GREP_PATH" -v '^$' | egrep -v "$GVM_ROOT/(pkgsets|gos|bin)" | tr "\n" ":" | sed 's/:*$//')"
 	export GVM_PATH_BACKUP="$PATH"
 }
 


### PR DESCRIPTION
If `grep` is an alias with `-n` option the resulting PATH is not usable.