### PR TITLE
Resolves possible error in user variable path assumptions

### DIFF
--- a/binscripts/gvm-installer
+++ b/binscripts/gvm-installer
@@ -45,7 +45,7 @@ EOF
 BRANCH=${1:-master}
 GVM_DEST=${2:-$HOME}
 GVM_NAME="gvm"
-SRC_REPO=${SRC_REPO:-https://github.com/moovweb/gvm.git}
+SRC_REPO=${SRC_REPO:-https://github.com/ahaymond/gvm.git}
 
 [ "$GVM_DEST" = "$HOME" ] && GVM_NAME=".gvm"
 

--- a/binscripts/gvm-installer
+++ b/binscripts/gvm-installer
@@ -45,7 +45,7 @@ EOF
 BRANCH=${1:-master}
 GVM_DEST=${2:-$HOME}
 GVM_NAME="gvm"
-SRC_REPO=${SRC_REPO:-https://github.com/ahaymond/gvm.git}
+SRC_REPO=${SRC_REPO:-https://github.com/moovweb/gvm.git}
 
 [ "$GVM_DEST" = "$HOME" ] && GVM_NAME=".gvm"
 

--- a/scripts/cross
+++ b/scripts/cross
@@ -20,7 +20,7 @@ display_list() {
 	exit 1
 }
 
-which go &> /dev/null || display_fatal "Only available in versions after Go 1"
+command -v go &> /dev/null || display_fatal "Only available in versions after Go 1"
 
 [ -z "$1" ] && display_list
 

--- a/scripts/function/display_error
+++ b/scripts/function/display_error
@@ -1,5 +1,5 @@
 display_error() {
-	which tput &> /dev/null
+	command -v tput &> /dev/null
 	if [[ "$?" == "0" ]]  && [[ "$TERM" == "xterm" ]]; then
 		tput sgr0
 		tput setaf 1

--- a/scripts/function/display_fatal
+++ b/scripts/function/display_fatal
@@ -1,5 +1,5 @@
 display_fatal() {
-	which tput &> /dev/null
+	command -v tput &> /dev/null
 	if [[ "$?" == "0" ]]  && [[ "$TERM" == "xterm" ]]; then
 		tput sgr0
 		tput setaf 1

--- a/scripts/function/display_message
+++ b/scripts/function/display_message
@@ -1,5 +1,5 @@
 display_message() {
-	which tput &> /dev/null
+	command -v tput &> /dev/null
 	if [[ "$?" == "0" ]]  && [[ "$TERM" == "xterm" ]]; then
 		# GREEN!
 		tput sgr0

--- a/scripts/function/display_warning
+++ b/scripts/function/display_warning
@@ -1,5 +1,5 @@
 display_warning() {
-	which tput &> /dev/null
+	command -v tput &> /dev/null
 	if [[ "$?" == "0" ]]  && [[ "$TERM" == "xterm" ]]; then
 		# YELLOW!
 		tput sgr0

--- a/scripts/function/tools
+++ b/scripts/function/tools
@@ -4,8 +4,8 @@ GREP_ERROR="GVM couldn't find grep"
 SORT_ERROR="GVM couldn't find sort"
 HEAD_ERROR="GVM couldn't find head"
 
-LS_PATH=$(unalias ls &> /dev/null; which ls) || display_error "$LS_ERROR" || return 1
-GREP_PATH=$(unalias grep &> /dev/null; which grep) || display_error "$GREP_ERROR" || return 1
-SORT_PATH=$(unalias sort &> /dev/null; which sort) || display_error "$SORT_ERROR" || return 1
-HEAD_PATH=$(unalias head &> /dev/null; which head) || display_error "$HEAD_ERROR" || return 1
+LS_PATH=$(unalias ls &> /dev/null; command -v ls) || display_error "$LS_ERROR" || return 1
+GREP_PATH=$(unalias grep &> /dev/null; command -v grep) || display_error "$GREP_ERROR" || return 1
+SORT_PATH=$(unalias sort &> /dev/null; command -v sort) || display_error "$SORT_ERROR" || return 1
+HEAD_PATH=$(unalias head &> /dev/null; command -v head) || display_error "$HEAD_ERROR" || return 1
 

--- a/scripts/gvm-check
+++ b/scripts/gvm-check
@@ -4,7 +4,7 @@
 error_message=""
 
 # Check for git
-which git &> /dev/null ||
+command -v git &> /dev/null ||
 	error_message="${error_message}
 Could not find git
 
@@ -12,35 +12,35 @@ Could not find git
   mac:   brew install mercurial
 "
 # Check for ar
-which ar &> /dev/null ||
+command -v ar &> /dev/null ||
 	error_message="${error_message}
 Could not find binutils
 
   linux: apt-get install binutils
 "
 # Check for bison
-which bison &> /dev/null ||
+command -v bison &> /dev/null ||
 	error_message="${error_message}
 Could not find bison
 
   linux: apt-get install bison
 "
 # Check for gcc
-which gcc &> /dev/null ||
+command -v gcc &> /dev/null ||
 	error_message="${error_message}
 Could not find gcc
 
   linux: apt-get install gcc
 "
 # Check for make
-which make &> /dev/null ||
+command -v make &> /dev/null ||
 	error_message="${error_message}
 Could not find make
 
   linux: apt-get install make
 "
 # Check for curl
-which curl &> /dev/null ||
+command -v curl &> /dev/null ||
 	error_message="${error_message}
 Could not find curl
 

--- a/scripts/install
+++ b/scripts/install
@@ -240,7 +240,7 @@ install_gb() {
 }
 
 install_goprotobuf() {
-	which protoc &> /dev/null || display_warning "Could not find protocol buffer compiler
+	command -v protoc &> /dev/null || display_warning "Could not find protocol buffer compiler
 
   linux: apt-get install protobuf-compiler
   mac:   brew install protobuf
@@ -285,7 +285,7 @@ install_from_source() {
 	install_go
 
 	GVM_GOINSTALL="goinstall"
-	which goinstall &> /dev/null ||
+	command -v goinstall &> /dev/null ||
 		GVM_GOINSTALL="go get"
 
 	x="$(cd "$GO_CACHE_PATH" && git tag)"; echo "${x#*b0819469a6df}" | $GREP_PATH "$version " &> /dev/null


### PR DESCRIPTION
This fix removes using the system `which` command for determining the
path for the following commands:
    - ls
    - grep
    - sort
    - head

It instead will use the `command -v` builtin in order to determine the
various paths to the binary applications. Use of which leaves open
the possibility for bugs and different use cases on various systems.

For more info on why this is a bad practice see:
http://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script