### PR TITLE
Add which checking in gvm-installer

### DIFF
--- a/binscripts/gvm-installer
+++ b/binscripts/gvm-installer
@@ -51,6 +51,10 @@ SRC_REPO=${SRC_REPO:-https://github.com/moovweb/gvm.git}
 
 [ -d "$GVM_DEST/$GVM_NAME" ] && display_error "Already installed!"
 [ -d "$GVM_DEST" ] || mkdir -p "$GVM_DEST" > /dev/null 2>&1 || display_error "Failed to create $GVM_DEST"
+[ -z "$(which which)" ] && display_error "Could not find which
+
+  redhat/centos: yum install which
+"
 [ -z "$(which git)" ] && display_error "Could not find git
 
   debian/ubuntu: apt-get install git


### PR DESCRIPTION
Some minimal installed Linux distributions didn't bundled which package,
So gvm-installer will complain a mistake error - `Could not find git`

The pull request fix this problem.
