### PR TITLE
Fix issue #126

### DIFF
--- a/scripts/env/use
+++ b/scripts/env/use
@@ -21,6 +21,7 @@ function gvm_use() {
 
 	gvm_export_path
 	. "$GVM_ROOT/environments/$fuzzy_match" &> /dev/null || display_error "Couldn't source environment" || return 1
+	gvm_environment_sanitize "$fuzzy_match"
 	if [[ "$2" == "--default" ]]; then
 		cp "$GVM_ROOT/environments/$fuzzy_match" "$GVM_ROOT/environments/default" || display_error "Couldn't make $fuzzy_match default"
 	fi

--- a/scripts/function/gvm_environment_sanitize
+++ b/scripts/function/gvm_environment_sanitize
@@ -4,9 +4,7 @@ function gvm_environment_sanitize() {
 	if [[ "${ACTIVE_GO/${GOROOT}}" != "/bin/go" ]]; then
 		OLD_GOROOT=$GOROOT && unset GOROOT
 		GOROOT=$(go env GOROOT)
-		sed 's|'${OLD_GOROOT}'|'${GOROOT}'|g' "$GVM_ROOT/environments/$1" > \
-			"$GVM_ROOT/environments/$1.sanity" && \
-			mv "$GVM_ROOT/environments/$1"{.sanity,}
+		sed -i 's|'${OLD_GOROOT}'|'${GOROOT}'|g' "$GVM_ROOT/environments/$1"
 		. "$GVM_ROOT/environments/$1" &> /dev/null
 	fi
 }

--- a/scripts/function/gvm_environment_sanitize
+++ b/scripts/function/gvm_environment_sanitize
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+function gvm_environment_sanitize() {
+	local ACTIVE_GO=$(which go)
+	if [[ "${ACTIVE_GO/${GOROOT}}" != "/bin/go" ]]; then
+		OLD_GOROOT=$GOROOT && unset GOROOT
+		GOROOT=$(go env GOROOT)
+		sed 's|'${OLD_GOROOT}'|'${GOROOT}'|g' "$GVM_ROOT/environments/$1" > \
+			"$GVM_ROOT/environments/$1.sanity" && \
+			mv "$GVM_ROOT/environments/$1"{.sanity,}
+		. "$GVM_ROOT/environments/$1" &> /dev/null
+	fi
+}


### PR DESCRIPTION
This commit adds a fix for issue #126, where an update to system go (usually with Homebrew) breaks the current system environment created by gvm. The fix proposal sanitizes the environment saved, updating it when/if necessary.