### PR TITLE
Fix downloading of OSX binaries

### DIFF
--- a/scripts/function/compare_version
+++ b/scripts/function/compare_version
@@ -1,0 +1,24 @@
+compare_version() {
+	if [[ $1 == $2 ]]; then
+		return 0
+	fi
+	local IFS=.
+	local i ver1=($1) ver2=($2) 
+	# fill empty fields in ver1 with zeros
+	for ((i=${#ver1[@]}; i<${#ver2[@]}; i++)); do
+		ver1[i]=0
+	done
+	for ((i=0; i<${#ver1[@]}; i++)); do
+	if [[ -z ${ver2[i]} ]]; then
+		# fill empty fields in ver2 with zeros
+		ver2[i]=0
+	fi
+	if ((10#${ver1[i]} > 10#${ver2[i]})); then
+		return 1
+	fi
+	if ((10#${ver1[i]} < 10#${ver2[i]})); then
+		return 2
+	fi
+	done
+	return 0
+}

--- a/scripts/function/extract_version
+++ b/scripts/function/extract_version
@@ -1,0 +1,12 @@
+extract_version(){
+	# Go versions can either be go* or release*
+	# They can also have the suffix rc or betaN
+
+	# Early versions can be 0.0.1
+	if [ $(echo $1 | grep release) ]; then
+		echo "0.0.1"
+	else
+		# Let's strip those prefixes and suffixes
+		echo "$(echo "$1" | sed 's/^go\(.*\)/\1/g; s/beta.*//g; s/rc.*//g')"
+	fi
+}

--- a/scripts/install
+++ b/scripts/install
@@ -152,7 +152,6 @@ install_go() {
 
 download_binary() {
 	mkdir -p $GO_INSTALL_ROOT >> "${GVM_ROOT}/logs/go-${GO_NAME}-download-binary" 2>&1
-
 	if [ "$(uname)" == "Darwin" ]; then
 		GVM_OS="darwin"
 		osx_major_version="$(sw_vers -productVersion | cut -d "." -f 2)"
@@ -176,7 +175,13 @@ download_binary() {
 		GVM_ARCH="386"
 	fi
 
-	GO_BINARY_FILE=${VERSION}.${GVM_OS}-${GVM_ARCH}${GVM_OS_VERSION}.tar.gz
+	SEMVER=$(extract_version $VERSION)
+	compare_version $SEMVER "1.4.3"
+	if [ $? -eq 2 ]; then
+		GO_BINARY_FILE=${VERSION}.${GVM_OS}-${GVM_ARCH}${GVM_OS_VERSION}.tar.gz
+	else
+		GO_BINARY_FILE=${VERSION}.${GVM_OS}-${GVM_ARCH}.tar.gz
+	fi
 	GO_BINARY_URL="http://golang.org/dl/${GO_BINARY_FILE}"
 	GO_BINARY_PATH=${GVM_ROOT}/archive/${GO_BINARY_FILE}
 


### PR DESCRIPTION
From version 1.4.3 onwards, the naming convention of downloads from Golang.org changed.

This PR addresses this by comparing the requested version to 1.4.3
If it's earlier use the old format
Otherwise, use the new format


Signed-off-by: Dave Tucker <dave@dtucker.co.uk>