### PR TITLE
set GOROOT_BOOTSTRAP with current go compiler's path

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -79,9 +79,16 @@ copy_source() {
 }
 
 
+set_goroot_bootstrap() {
+    if [ -z "$GOROOT_BOOTSTRAP" ]; then
+        local goroot=$(go env GOROOT 2>/dev/null)
+        export GOROOT_BOOTSTRAP=${goroot%%/bin/go}
+    fi
+}
+
 compile_go() {
 	display_message " * Compiling..."
-	[ -z "$GOROOT_BOOTSTRAP" ] && export GOROOT_BOOTSTRAP=$GOROOT
+	set_goroot_bootstrap
 	unset GOARCH && unset GOOS && unset GOPATH && unset GOBIN && unset GOROOT &&
 	export GOBIN=$GO_INSTALL_ROOT/bin &&
 	export PATH=$GOBIN:$PATH &&


### PR DESCRIPTION
go1.6 installed via homebrew does not set the `GOROOT` environment variable.
So use current go compiler's path as a fallback.
