### PR TITLE
Fix a problem on macOS 'sed' (BSD) version

### DIFF
--- a/scripts/function/gvm_environment_sanitize
+++ b/scripts/function/gvm_environment_sanitize
@@ -4,7 +4,7 @@ function gvm_environment_sanitize() {
 	if [[ "${ACTIVE_GO/${GOROOT}}" != "/bin/go" ]]; then
 		OLD_GOROOT="$GOROOT" && unset GOROOT
 		GOROOT="$(go env GOROOT)"
-		sed -i '' 's|'${OLD_GOROOT}'|'${GOROOT}'|g' "$GVM_ROOT/environments/$1"
+		$SED_PATH -i'' -e 's|'${OLD_GOROOT}'|'${GOROOT}'|g' "$GVM_ROOT/environments/$1"
 		. "$GVM_ROOT/environments/$1" &> /dev/null
 	fi
 }

--- a/scripts/function/gvm_environment_sanitize
+++ b/scripts/function/gvm_environment_sanitize
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 function gvm_environment_sanitize() {
-	local ACTIVE_GO=$(which go)
+	local ACTIVE_GO="$(which go)"
 	if [[ "${ACTIVE_GO/${GOROOT}}" != "/bin/go" ]]; then
-		OLD_GOROOT=$GOROOT && unset GOROOT
-		GOROOT=$(go env GOROOT)
-		sed -i 's|'${OLD_GOROOT}'|'${GOROOT}'|g' "$GVM_ROOT/environments/$1"
+		OLD_GOROOT="$GOROOT" && unset GOROOT
+		GOROOT="$(go env GOROOT)"
+		sed -i '' 's|'${OLD_GOROOT}'|'${GOROOT}'|g' "$GVM_ROOT/environments/$1"
 		. "$GVM_ROOT/environments/$1" &> /dev/null
 	fi
 }

--- a/scripts/function/tools
+++ b/scripts/function/tools
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 LS_ERROR="GVM couldn't find ls"
+SED_ERROR="GVM couldn't find sed"
 GREP_ERROR="GVM couldn't find grep"
 SORT_ERROR="GVM couldn't find sort"
 HEAD_ERROR="GVM couldn't find head"
 
 LS_PATH=$(unalias ls &> /dev/null; command -v ls) || display_error "$LS_ERROR" || return 1
+SED_PATH=$(unalias sed &> /dev/null; command -v sed) || display_error "$SED_ERROR" || return 1
 GREP_PATH=$(unalias grep &> /dev/null; command -v grep) || display_error "$GREP_ERROR" || return 1
 SORT_PATH=$(unalias sort &> /dev/null; command -v sort) || display_error "$SORT_ERROR" || return 1
 HEAD_PATH=$(unalias head &> /dev/null; command -v head) || display_error "$HEAD_ERROR" || return 1


### PR DESCRIPTION
There is a required parameter for the inline edit option on macOS 'sed' version.
The original change doesn't have this and so, the inline edit option with the
missing parameter was causing macOS sed's command to fail.
This commit also double quoted the path parameters to avoid possible failures
due to usage of spaces into those pathnames.
