### PR TITLE
uses the new url for alternate binary downloads

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -190,8 +190,8 @@ download_binary() {
 		curl -s -f -L $GO_BINARY_URL > ${GO_BINARY_PATH}
 
 		if [[ $? -ne 0 ]]; then
-			display_error "Failed to download binary go from http://golang.org. Trying https://go.googlecode.com"
-			GO_BINARY_URL="https://go.googlecode.com/files/${GO_BINARY_FILE}"
+			display_error "Failed to download binary go from http://golang.org. Trying https://storage.googleapis.com"
+			GO_BINARY_URL="https://storage.googleapis.com/golang/${GO_BINARY_FILE}"
 
 			curl -s -f -L $GO_BINARY_URL > ${GO_BINARY_PATH}
 


### PR DESCRIPTION
catching up with hosting changes for golang binaries
