### PR TITLE
Fix Binary URL to storage.googleapis.com

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -183,7 +183,7 @@ download_binary() {
 	else
 		GO_BINARY_FILE=${VERSION}.${GVM_OS}-${GVM_ARCH}.tar.gz
 	fi
-	GO_BINARY_URL="http://golang.org/dl/${GO_BINARY_FILE}"
+	GO_BINARY_URL="https://storage.googleapis.com/golang/${GO_BINARY_FILE}"
 	GO_BINARY_PATH=${GVM_ROOT}/archive/${GO_BINARY_FILE}
 
 	if [ ! -f $GO_BINARY_PATH ]; then


### PR DESCRIPTION
http://golang.org/dl/ does not work for binary download URL, so changed to https://storage.googleapis.com/golang

I confirmed environments below;

- macOS Sierra (OSX 10.12.4)
    - Go 1.4.2
    - Go 1.4.3
    - Go 1.8.1
- CentOS Linux 7.2
    - Go 1.4.2
    - Go 1.4.3
    - Go 1.8.1
