### PR TITLE
add: --print-path to be able to just print the path

### DIFF
--- a/scripts/pkgenv
+++ b/scripts/pkgenv
@@ -7,6 +7,7 @@ function show_usage() {
   echo
   echo "       -h, --help   Display this message."
   echo "       -o, --output Write content to stdout"
+  echo "       -p, --print-path Print the path of the environments file"
   echo
   echo "The [packageset-name] is optional."
   echo
@@ -21,6 +22,8 @@ for i in "$@"; do
     -o|--output*)
       output=true
     ;;
+    -p|--print-path*)
+      print_path=true
     *)
       gvm_env="$i"
     ;;
@@ -39,6 +42,11 @@ env_file=$GVM_ROOT/environments/$gvm_go_name$gvm_env
 
 if [ $output ]; then
     cat "$env_file"
+    exit 0
+fi
+
+if [ $print_path ]; then
+    echo $env_file
     exit 0
 fi
 


### PR DESCRIPTION
`--print-path` option simply prints the environments file path and exits. This is useful for automating workflows. Since opening up an editor hinders automation. This way, the path can used to read the file correctly, and appropriately modify pkgset path from automation scripts.