### PR TITLE
When a stale installation is stopping 'gvm-installer', tell me how to remove the other one

### DIFF
--- a/binscripts/gvm-installer
+++ b/binscripts/gvm-installer
@@ -49,7 +49,11 @@ SRC_REPO=${SRC_REPO:-https://github.com/moovweb/gvm.git}
 
 [ "$GVM_DEST" = "$HOME" ] && GVM_NAME=".gvm"
 
-[ -d "$GVM_DEST/$GVM_NAME" ] && display_error "Already installed!"
+[ -d "$GVM_DEST/$GVM_NAME" ] && display_error \
+    "Already installed! Remove old installation by running
+
+    rm -rf $GVM_DEST/$GVM_NAME"
+
 [ -d "$GVM_DEST" ] || mkdir -p "$GVM_DEST" > /dev/null 2>&1 || display_error "Failed to create $GVM_DEST"
 [ -z "$(which git)" ] && display_error "Could not find git
 


### PR DESCRIPTION
I used `gvm` for a while and the uninstalled it probably in a in improper way. Now when trying to install using the instructions in the README I just get a message saying

     ERROR: Already installed!

I think if we add the path that is causing this to the error message it will be easier to resolved. (My solution was to pull the repo and investigate the code, can't imagine the every developer will have that patience.)

Resolves https://github.com/moovweb/gvm/issues/291.