### PR TITLE
Sort Go versions numerically

### DIFF
--- a/scripts/listall
+++ b/scripts/listall
@@ -46,6 +46,6 @@ for version in $versions; do
 	else
 		echo "   $version"
 	fi
-done
+done | sort -V
 echo
 


### PR DESCRIPTION
With the release of Go 1.10, versions are now sorted incorrectly:

    ...
    go1.1
    go1.1.1
    go1.1.2
    go1.10
    go1.10.1
    go1.10beta1
    go1.10beta2
    go1.10rc1
    go1.10rc2
    go1.1rc2
    go1.1rc3
    go1.2
    go1.2.1
    go1.2.2
    go1.2rc2
    ...

By applying `sort -V` we get version sorting, see `man sort` for more details

```
     -V, --version-sort
             Sort version numbers...
```

Our sorting result will then be 

    ...
    go1.8.6
    go1.8.7
    go1.9
    go1.9beta1
    go1.9beta2
    go1.9rc1
    go1.9rc2
    go1.9.1
    go1.9.2
    go1.9.3
    go1.9.4
    go1.9.5
    go1.10
    go1.10beta1
    go1.10beta2
    go1.10rc1
    go1.10rc2
    go1.10.1
    ...