### PR TITLE
Fix install goroot

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -81,7 +81,7 @@ copy_source() {
 
 compile_go() {
 	display_message " * Compiling..."
-	[ -z "$GOROOT_BOOTSTRAP" ] && export GOROOT_BOOTSTRAP=$GOROOT
+	[ -z "$GOROOT_BOOTSTRAP" ] && export GOROOT_BOOTSTRAP=$(go env GOROOT)
 	unset GOARCH && unset GOOS && unset GOPATH && unset GOBIN && unset GOROOT &&
 	export GOBIN=$GO_INSTALL_ROOT/bin &&
 	export PATH=$GOBIN:$PATH &&

--- a/scripts/install
+++ b/scripts/install
@@ -81,7 +81,7 @@ copy_source() {
 
 compile_go() {
 	display_message " * Compiling..."
-	[ -z "$GOROOT_BOOTSTRAP" ] && export GOROOT_BOOTSTRAP=$(go env GOROOT)
+	[ -z "$GOROOT_BOOTSTRAP" ] && export GOROOT_BOOTSTRAP=$(go env GOROOT) 
 	unset GOARCH && unset GOOS && unset GOPATH && unset GOBIN && unset GOROOT &&
 	export GOBIN=$GO_INSTALL_ROOT/bin &&
 	export PATH=$GOBIN:$PATH &&


### PR DESCRIPTION

Currently the install script is failing on compiling stage when using `$GOROOT` environment variable. Instead, as stated on #275 , we should use `go env` over relying on shell environment. 

```
➜  ~ go env GOROOT
/usr/local/go
➜  ~ echo $GOROOT

```

