### PR TITLE
Overwrite destination if exists when creating symlink

### DIFF
--- a/scripts/linkthis
+++ b/scripts/linkthis
@@ -4,6 +4,7 @@
 function show_usage() {
 	echo "Usage: gvm linkthis [package-name] [options]"
 	echo "    -h, --help     Display this message."
+	echo "    -f, --force    Remove existing destination and create symlink again."
 	echo
 	echo "If the [package-name] is provided, it will be used in the path based"
 	echo "at \${GOPATH%%:*}/src, e.g.:"
@@ -21,6 +22,9 @@ function read_command_line() {
 				show_usage
 				exit 0
 			;;
+			-f|--force*)
+				force="-f"
+			;;
 			-*|--*)
 				echo "Invalid option $i"
 				show_usage
@@ -35,10 +39,11 @@ function read_command_line() {
 
 package_name="$(basename "$PWD")"
 package_name_basename="$package_name"
+force=""
 
 read_command_line "$@"
 
 target="${GOPATH%%:*}/src/$package_name"
 
 mkdir -p "$(dirname "$target")"
-ln -sv "$PWD" "$target"
+ln -sv $force "$PWD" "$target"


### PR DESCRIPTION
Running `gvm linkthis` multiple times will throw an error like below due to existence of destination.

```
ln: failed to create symbolic link '...path...': File exists
```


So this PR, is adding another option (`-f`) to `linkthis` script to be passed down to `ln` command for overwriting.