### PR TITLE
change default config of GO_SOURCE_URL to https://github.com/golang/go

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -21,7 +21,7 @@ read_command_line() {
 		show_usage
 		exit 1
 	fi
-	GO_SOURCE_URL=https://go.googlesource.com/go
+	GO_SOURCE_URL=https://github.com/golang/go
 	for i in "$@"; do
 		case $i in
 			-s=*|--source=*)

--- a/scripts/listall
+++ b/scripts/listall
@@ -32,7 +32,7 @@ read_command_line "$@"
 echo
 display_message "gvm gos (available)"
 echo
-versions=$(git ls-remote -t https://go.googlesource.com/go | awk -F/ '{ print $NF }' | $SORT_PATH)
+versions=$(git ls-remote -t https://github.com/golang/go | awk -F/ '{ print $NF }' | $SORT_PATH)
 if [[ $? -ne 0 ]]; then
 	display_fatal "Failed to get version list from Google"
 fi


### PR DESCRIPTION
googlesource.com is blocked by the GFW in China.
* In  nvm's "script/install", line 24:
default:
```GO_SOURCE_URL=https://go.googlesource.com/go```


* As well in nvm's "script/listall", line 35:
```versions=$(git ls-remote -t https://go.googlesource.com/go | awk -F/ '{ print $NF }' | $SORT_PATH)```

"gvm install" has -s parameter, but "gvm listall" not.
**It's better change:**
```https://go.googlesource.com/go``` 
to 
```https://github.com/golang/go```
