### PR TITLE
Uppercase default answer in implode prompt

### DIFF
--- a/scripts/env/implode
+++ b/scripts/env/implode
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function gvm_implode() {
-  read -p "Are you sure? [Y/n] " -n 1 -r
+  read -p "Are you sure? [y/N] " -n 1 -r
   echo
   if [[ ! $REPLY =~ ^[Yy]$ ]]; then
    display_message "Action cancelled"


### PR DESCRIPTION
Normally, if a command-line prompt gives two options and one option is uppercased, that means no answer is the same as the uppercased answer.

This PR fixes the prompt users receive when running `implode` so that the 'N' is capitalized instead of the 'Y.' There's no behavioral change; this just updates the prompt values to match the true default behavior.