### PR TITLE
Change the way of sorting by version in 'listall'

### DIFF
--- a/scripts/listall
+++ b/scripts/listall
@@ -46,6 +46,6 @@ for version in $versions; do
 	else
 		echo "   $version"
 	fi
-done | sort -V
+done | $SED_PATH -E -e 's/([^0-9]+)/ \1 /g' | $SORT_PATH -k1,1 -k2,2n -k3,3 -k4,4n -k5,5 -k6,6n | $SED_PATH -E -e 's/ ([^0-9]+) /\1/g'
 echo
 


### PR DESCRIPTION
This PR changes the way of sorting by version in `listall`. 
As a problem is reported at #305, `-V` option isn't available with `sort` on MacOS, and `listall` doesn't work correctly.
By this PR, go versions are sorted correctly both on Linux and MacOS.

There's also another advantage. In the current method, the first minor version comes first, then beta, rc followed by the patch versions at the end.

~~~
   go1.11
   go1.11beta1
   go1.11beta2
   go1.11beta3
   go1.11rc1
   go1.11rc2
   go1.11.1
   go1.11.2
   go1.11.3
   go1.11.4
~~~ 

In the method of this PR, betas and rcs comes last. I think this is easier to see.

~~~
   go1.11
   go1.11.1
   go1.11.2
   go1.11.3
   go1.11.4
   go1.11beta1
   go1.11beta2
   go1.11beta3
   go1.11rc1
   go1.11rc2
~~~

Also, release versions are sorted naturally.

