### PR TITLE
Look up for Go version in .go-version file

### DIFF
--- a/scripts/env/use
+++ b/scripts/env/use
@@ -5,6 +5,7 @@ function gvm_use() {
 		return 1
 	fi
 
+
 	if [[ "x$1" == x ]]; then
 		if [[ -s "$PWD/.go-version" ]]; then
 			local _go_version=$(cat .go-version | tr -d '\n')
@@ -14,6 +15,8 @@ function gvm_use() {
 			return 1
 		fi
 	fi
+
+	local _go_version="$1"
 
 	if [[ "$_go_version" =~ ^(.+)@(.+)$ ]]; then
 		local VERSION="${BASH_REMATCH[1]}"

--- a/scripts/env/use
+++ b/scripts/env/use
@@ -14,9 +14,9 @@ function gvm_use() {
 			display_error "Please specify the version"
 			return 1
 		fi
+	else
+		local _go_version="$1"
 	fi
-
-	local _go_version="$1"
 
 	if [[ "$_go_version" =~ ^(.+)@(.+)$ ]]; then
 		local VERSION="${BASH_REMATCH[1]}"

--- a/scripts/env/use
+++ b/scripts/env/use
@@ -6,15 +6,20 @@ function gvm_use() {
 	fi
 
 	if [[ "x$1" == x ]]; then
-		display_error "Please specify the version"
-		return 1
+		if [[ -s "$PWD/.go-version" ]]; then
+			local _go_version=$(cat .go-version | tr -d '\n')
+			display_message "Using version $_go_version from .go-version"
+		else
+			display_error "Please specify the version"
+			return 1
+		fi
 	fi
 
-	if [[ "$1" =~ ^(.+)@(.+)$ ]]; then
+	if [[ "$_go_version" =~ ^(.+)@(.+)$ ]]; then
 		local VERSION="${BASH_REMATCH[1]}"
 		local PKGSET="${BASH_REMATCH[2]}"
 	else
-		local VERSION=$1
+		local VERSION=$_go_version
         fi
 
 	fuzzy_match=$($LS_PATH "$GVM_ROOT/gos" | $SORT_PATH | $GREP_PATH "$VERSION" | $HEAD_PATH -n 1 | $GREP_PATH "$VERSION")
@@ -31,7 +36,7 @@ function gvm_use() {
 	gvm_export_path
 	. "$GVM_ROOT/environments/$fuzzy_match" &> /dev/null || display_error "Couldn't source environment" || return 1
 	gvm_environment_sanitize "$fuzzy_match"
-	if [[ "$2" == "--default" ]]; then
+	if [[ "$2" == "--default" ]] || [[ "$1" == "--default" && "$#" == "1" ]]; then
 		cp "$GVM_ROOT/environments/$fuzzy_match" "$GVM_ROOT/environments/default" || display_error "Couldn't make $fuzzy_match default"
 	fi
 

--- a/tests/gvm_use_comment_test.sh
+++ b/tests/gvm_use_comment_test.sh
@@ -3,3 +3,11 @@ gvm use go1.7.6 # status=0
 go version # status=0; match=/go1\.7\.6/
 gvm use go1.6.4 # status=0
 go version # status=0; match=/go1\.6\.4/
+
+echo "go1.7.6" > .go-version
+gvm use # status=0
+go version # status=0; match=/go1\.7\.6/
+
+echo "go1.6.4" > .go-version
+gvm use --default # status=0
+go version # status=0; match=/go1\.6\.4/


### PR DESCRIPTION
When `use` command is executed without arguments, now it checks for a `.go-version` file in current working directory and if any, use Go version from the file.