### PR TITLE
Add GO_BINARY_BASE_URL env

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -185,7 +185,8 @@ download_binary() {
 	else
 		GO_BINARY_FILE=${VERSION}.${GVM_OS}-${GVM_ARCH}.tar.gz
 	fi
-	# please set `GO_BINARY_BASE_URL` to `https://dl.google.com/go` in China.
+	# `GO_BINARY_BASE_URL` env allow user setting base URL for binaries
+	# download, e.g. "https://dl.google.com/go".
 	GO_BINARY_BASE_URL=${GO_BINARY_BASE_URL:-"https://storage.googleapis.com/golang"}
 	GO_BINARY_URL="${GO_BINARY_BASE_URL}/${GO_BINARY_FILE}"
 	GO_BINARY_PATH=${GVM_ROOT}/archive/${GO_BINARY_FILE}

--- a/scripts/install
+++ b/scripts/install
@@ -185,7 +185,9 @@ download_binary() {
 	else
 		GO_BINARY_FILE=${VERSION}.${GVM_OS}-${GVM_ARCH}.tar.gz
 	fi
-	GO_BINARY_URL="https://storage.googleapis.com/golang/${GO_BINARY_FILE}"
+	# please set `GO_BINARY_BASE_URL` to `https://dl.google.com/go` in China.
+	GO_BINARY_BASE_URL=${GO_BINARY_BASE_URL:-"https://storage.googleapis.com/golang"}
+	GO_BINARY_URL="${GO_BINARY_BASE_URL}/${GO_BINARY_FILE}"
 	GO_BINARY_PATH=${GVM_ROOT}/archive/${GO_BINARY_FILE}
 
 	if [ ! -f $GO_BINARY_PATH ]; then


### PR DESCRIPTION
It's convenient to provide the ability to change the default base URL for downloading go binaries, as the default setting - `https://storage.googleapis.com/golang` - may be not accessible in some regions (e.g. China).