### PR TITLE
update zsh profile if exists from installer

### DIFF
--- a/binscripts/gvm-installer
+++ b/binscripts/gvm-installer
@@ -98,9 +98,10 @@ source_line="[[ -s \"${GVM_DEST}/$GVM_NAME/scripts/gvm\" ]] && source \"${GVM_DE
 source_file="${GVM_DEST}/$GVM_NAME/scripts/gvm"
 
 if [ -z "$GVM_NO_UPDATE_PROFILE" ] ; then
-  if [ -n "$ZSH_NAME" ]; then
+  if [ -f "$HOME/.zshrc" ]; then
     update_profile "$HOME/.zshrc"
-  elif [ "$(uname)" == "Linux" ]; then
+  fi
+  if [ "$(uname)" == "Linux" ]; then
     update_profile "$HOME/.bashrc" || update_profile "$HOME/.bash_profile"
   elif [ "$(uname)" == "Darwin" ]; then
     update_profile "$HOME/.profile" || update_profile "$HOME/.bash_profile"


### PR DESCRIPTION
Update .zshrc if it exists, even if the installer is ran from another shell. This solves the issue that gvm is not installed correctly for zsh if the installer is ran from another shell like bash.