### PR TITLE
Add support for listing and installing dev branches

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -4,6 +4,7 @@
 function show_usage() {
 	echo "Usage: gvm install [version] [options]"
 	echo "    -s,  --source=SOURCE      Install Go from specified source."
+	echo "    -u,  --update-source      Fetch latest source."
 	echo "    -n,  --name=NAME          Override the default name for this version."
 	echo "    -pb, --with-protobuf      Install Go protocol buffers."
 	echo "    -b,  --with-build-tools   Install package build tools."
@@ -24,6 +25,9 @@ read_command_line() {
 	GO_SOURCE_URL=https://github.com/golang/go
 	for i in "$@"; do
 		case $i in
+			-u|--update-source)
+				UPDATE_SOURCE="true"
+			;;
 			-s=*|--source=*)
 				GO_SOURCE_URL=$(echo "$i" | sed 's/[-a-zA-Z0-9]*=//')
 			;;
@@ -65,6 +69,12 @@ download_source() {
 
 check_tag() {
     version=$(cd "$GO_CACHE_PATH" && git show-ref --heads --tags | awk -F/ '{ print $NF }' | $SORT_PATH | $GREP_PATH "$VERSION" | $HEAD_PATH -n 1 | $GREP_PATH -w "$VERSION")
+}
+
+check_branch() {
+    # create a local branch pointing at the given remote branch if possible
+    (cd "$GO_CACHE_PATH" && git branch -f "$VERSION" "origin/${VERSION}" >/dev/null 2>/dev/null) || return 1
+    version=${VERSION}
 }
 
 update_source() {
@@ -280,10 +290,10 @@ install_goprotobuf() {
 
 install_from_source() {
 	download_source
-	check_tag
-	if [[ "$?" == "1" ]]; then
+	check_tag || check_branch
+	if [[ "$?" == "1" || "$UPDATE_SOURCE" == "true" ]]; then
 		update_source
-		check_tag || display_fatal "Unrecognized Go version"
+		check_tag || check_branch || display_fatal "Unrecognized Go version"
 	fi
 	if [[ "$GO_NAME" == "" ]]; then
 		GO_NAME=$version

--- a/scripts/listall
+++ b/scripts/listall
@@ -36,6 +36,16 @@ versions=$(git ls-remote -t https://github.com/golang/go | awk -F/ '{ print $NF 
 if [[ $? -ne 0 ]]; then
 	display_fatal "Failed to get version list from Google"
 fi
+
+# include dev branches if listing all available versions
+dev_versions=()
+if [[ "$tag_filter" == "" ]]; then
+	dev_versions=$(git ls-remote --heads https://github.com/golang/go | grep /dev. | awk -F/dev. '{ print "dev." $NF }')
+	if [[ $? -ne 0 ]]; then
+		display_fatal "Failed to get dev branch list from Google"
+	fi
+fi
+
 for version in $versions; do
 	if [[ "$tag_filter" == "release" ]]; then
 		if [[ "${version:0:7}" == "release" ]]; then
@@ -47,5 +57,10 @@ for version in $versions; do
 		echo "   $version"
 	fi
 done | sort -V
+
+for version in $dev_versions; do
+	echo "   $version"
+done | sort -V
+
 echo
 


### PR DESCRIPTION
Includes ability to list/install from dev branches:

```sh
gvm listall -a

gvm gos (available)

   ...
   dev.boringcrypto
   dev.cc
   dev.cmdgo
   dev.debug
   dev.fuzz
   dev.garbage
   dev.gcfe
   dev.go2go
   dev.inline
   dev.link
   dev.power64
   dev.regabi
   dev.ssa
   dev.tls
   dev.typealias
   dev.typeparams
   dev.types
   dev.boringcrypto.go1.8
   dev.boringcrypto.go1.9
   dev.boringcrypto.go1.10
   dev.boringcrypto.go1.11
   dev.boringcrypto.go1.12
   dev.boringcrypto.go1.13
   dev.boringcrypto.go1.14
   dev.boringcrypto.go1.15
   dev.boringcrypto.go1.16
```

```sh
gvm install dev.boringcrypto.go1.16 --name=go1.16b
Installing dev.boringcrypto.go1.16 as go1.16b...
 * Compiling...
go1.16b successfully installed!
```

And since branches can change over time, also allows force-updating source in install with `--update-source` so the following works:

```sh
gvm uninstall go1.16b && gvm install dev.boringcrypto.go1.16 --update-source --name=go1.16b
```