### PR TITLE
Mention `go clean -modcache` in a fatal message

### DIFF
--- a/scripts/uninstall
+++ b/scripts/uninstall
@@ -9,7 +9,7 @@ fuzzy_match=$($LS_PATH "$GVM_ROOT/gos" | $SORT_PATH | $GREP_PATH "$1" | $HEAD_PA
 
 if [[ -d $GVM_ROOT/gos/$fuzzy_match ]]; then
 	rm -rf "$GVM_ROOT/pkgsets/$fuzzy_match" &> /dev/null ||
-		display_fatal "Couldn't remove pkgsets"
+		display_fatal "Couldn't remove pkgsets. Please run 'gvm use $1 && go clean -modcache' and retry uninstall."
 	rm -f "$GVM_ROOT/environments/$fuzzy_match" &> /dev/null ||
 		display_fatal "Couldn't remove environment files"
 	rm -f "$GVM_ROOT/environments/$fuzzy_match@"* &> /dev/null ||


### PR DESCRIPTION
Go modules folder is protected. So you need to clean the mod cache first when the mod cache data exists.
This added a message to solve that situation.

Related to #319.