### PR TITLE
Support macOS 11 Big Sur Binary Downloads

### DIFF
--- a/bin/gvm
+++ b/bin/gvm
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 [ -n "$GVM_DEBUG" ] && {
-  set -x
+	set -x
 }
 
 if [ -z "$GVM_ROOT" ]; then
@@ -19,7 +19,7 @@ fi
 
 command=$1
 if [[ $command == "implode" ]]; then
-  gvm_implode
+	gvm_implode
 	exit 0
 fi
 

--- a/scripts/install
+++ b/scripts/install
@@ -155,17 +155,6 @@ download_binary() {
 	mkdir -p $GO_INSTALL_ROOT >> "${GVM_ROOT}/logs/go-${GO_NAME}-download-binary" 2>&1
 	if [ "$(uname)" == "Darwin" ]; then
 		GVM_OS="darwin"
-		osx_major_version="$(sw_vers -productVersion | cut -d "." -f 2)"
-		if [ "${osx_major_version}" -ge 8 ]; then
-			GVM_OS_VERSION="-osx10.8"
-		elif [ "${osx_major_version}" -ge 6 ]; then
-			GVM_OS_VERSION="-osx10.6"
-		else
-			display_error "Binary Go unavailable for this platform"
-			rm -rf $GO_INSTALL_ROOT
-			rm -f $GO_BINARY_PATH
-			exit 1
-		fi
 	else
 		GVM_OS="linux"
 	fi
@@ -183,6 +172,24 @@ download_binary() {
 	SEMVER=$(extract_version $VERSION)
 	compare_version $SEMVER "1.4.3"
 	if [ $? -eq 2 ]; then
+		if [ "$GVM_OS" == "darwin" ]; then
+			macos_version="$(sw_vers -productVersion)"
+			macos_major_version="$(printf '%s' "$macos_version" | cut -d "." -f 1)"
+			if [ "${macos_major_version}" -eq 10 ]; then
+				macos_minor_version="$(printf '%s' "$macos_version" | cut -d "." -f 2)"
+				if [ "${macos_minor_version}" -ge 8 ]; then
+					GVM_OS_VERSION="-osx10.8"
+				elif [ "${macos_minor_version}" -ge 6 ]; then
+					GVM_OS_VERSION="-osx10.6"
+				fi
+			fi
+			if [ -z "$GVM_OS_VERSION" ]; then
+				display_error "Binary Go unavailable for this platform"
+				rm -rf $GO_INSTALL_ROOT
+				rm -f $GO_BINARY_PATH
+				exit 1
+			fi
+		fi
 		GO_BINARY_FILE=${VERSION}.${GVM_OS}-${GVM_ARCH}${GVM_OS_VERSION}.tar.gz
 	else
 		GO_BINARY_FILE=${VERSION}.${GVM_OS}-${GVM_ARCH}.tar.gz

--- a/scripts/install
+++ b/scripts/install
@@ -64,7 +64,7 @@ download_source() {
 }
 
 check_tag() {
-    version=$(cd "$GO_CACHE_PATH" && git show-ref --heads --tags | awk -F/ '{ print $NF }' | $SORT_PATH | $GREP_PATH "$VERSION" | $HEAD_PATH -n 1 | $GREP_PATH -w "$VERSION")
+	version=$(cd "$GO_CACHE_PATH" && git show-ref --heads --tags | awk -F/ '{ print $NF }' | $SORT_PATH | $GREP_PATH "$VERSION" | $HEAD_PATH -n 1 | $GREP_PATH -w "$VERSION")
 }
 
 update_source() {
@@ -173,9 +173,9 @@ download_binary() {
 	if [ "$(uname -m)" == "x86_64" ]; then
 		GVM_ARCH="amd64"
 	elif [ "$(uname -m)" == "ppc64le" ]; then
-	        GVM_ARCH="ppc64le"
+		GVM_ARCH="ppc64le"
 	elif [ "$(uname -m)" == "aarch64" ]; then
-      	        GVM_ARCH="arm64"
+		GVM_ARCH="arm64"
 	else
 		GVM_ARCH="386"
 	fi

--- a/scripts/install
+++ b/scripts/install
@@ -159,11 +159,12 @@ download_binary() {
 		GVM_OS="linux"
 	fi
 
-	if [ "$(uname -m)" == "x86_64" ]; then
+	arch="$(uname -m)"
+	if [ "$arch" == "x86_64" ]; then
 		GVM_ARCH="amd64"
-	elif [ "$(uname -m)" == "ppc64le" ]; then
+	elif [ "$arch" == "ppc64le" ]; then
 		GVM_ARCH="ppc64le"
-	elif [ "$(uname -m)" == "aarch64" ]; then
+	elif [ "$arch" == "aarch64" ] || [ "$arch" == "arm64" ]; then
 		GVM_ARCH="arm64"
 	else
 		GVM_ARCH="386"


### PR DESCRIPTION
There was some compatibility code for Golang versions less than 1.4.3 that broke installs on Big Sur. Prior to *1.4.3*, there were two versions for osx10.8 and osx10.6. *1.4.3* introduced a unified *amd64* version. When OS X changed the major version from 10 to 11, that logic broke.

This patch moves that compatibility logic into the "less than 1.4.3" check, and now checks both the major and minor version of macOS.

I tried a different patch that would download `go1.4.2.darwin-amd64-osx10.8.pkg` on Big Sur, and it _installed_ successfully, but `go version` printed a stack trace, so I adjusted the patch to print `Binary Go unavailable for this platform`. I tested, `go1.4.2` and it installs, but also crashes. `go1.5` installed and passed my `go version` test. We could write more code to protect Big Sur users from this, but I doubt many developers are still trying to use a Golang from 2015 on Big Sur, and I don't think my `go version` test is a comprehensive compatibility test anyways.

PS: I included a whitespace-only commit, as a few lines used spaces for indentation while the overwhelming majority of the file used tabs.