### PR TITLE
Allow other complete scripts to be run after gvm completion is sourced

### DIFF
--- a/scripts/completion
+++ b/scripts/completion
@@ -78,6 +78,8 @@ _gvm()
 			return 0
 		;;
 	esac
+
+	return 0
 }
 complete -F _gvm gvm
 

--- a/scripts/completion
+++ b/scripts/completion
@@ -81,5 +81,5 @@ _gvm()
 
 	return 0
 }
-complete -F _gvm gvm
+complete -o default -F _gvm gvm
 


### PR DESCRIPTION
When no match return 0 to allow other complete scripts to be run an default completion should be allowed