### PR TITLE
A small change in  "Installation" Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@ Installing
 
 To install:
 
-    bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
+    curl -sSL https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer | bash
 
-Or if you are using zsh just change `bash` with `zsh`
 
 Installing Go
 =============


### PR DESCRIPTION
The command  "bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)" 
**changed to** "curl -sSL https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer | bash".

The images below show working in bash and zsh.

![gvm-bash-armv7l](https://user-images.githubusercontent.com/31942862/126538914-57ce0bd2-8390-4961-b5d8-b15e6a4943bf.png)

![gvm-zsh](https://user-images.githubusercontent.com/31942862/126538953-2830b9e7-7e0f-4e2a-b6dc-2b69d22e9119.png)
