### PR TITLE
Add a step for installing Bison before

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,17 @@ Installing
 
 To install:
 
-    1.  Install [Bison](https://www.gnu.org/software/bison/):
-     
-        ```
-        sudo apt-get install bison
-        ```
-      
-    1.  Install gvm:
-    
-        ```
-        bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
-        ```
+1.  Install [Bison](https://www.gnu.org/software/bison/):
+
+    ```
+    sudo apt-get install bison
+    ```
+
+1.  Install gvm:
+
+    ```
+    bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
+    ```
 
 Or if you are using zsh just change `bash` with `zsh`
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,17 @@ Installing
 
 To install:
 
-    bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
+    1.  Install [Bison](https://www.gnu.org/software/bison/):
+     
+        ```
+        sudo apt-get install bison
+        ```
+      
+    1.  Install gvm:
+    
+        ```
+        bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
+        ```
 
 Or if you are using zsh just change `bash` with `zsh`
 


### PR DESCRIPTION
After installing gvm, when I tried to use it, I got an error about needing Bison:

$ gvm install go1.17
gvm use go1.17 [--default]

Could not find bison
  linux: apt-get install bison
ERROR: Missing requirements.