### PR TITLE
fix: 32 bit ARM

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -174,10 +174,12 @@ download_binary() {
 		GVM_ARCH="amd64"
 	elif [ "$(uname -m)" == "ppc64le" ]; then
 	        GVM_ARCH="ppc64le"
-	elif [ "$(uname -m)" == "aarch64" ]; then
+	elif [[ "$(uname -m)" == "aarch64" || "$(uname -m)" == "arm64" ]]; then
       	        GVM_ARCH="arm64"
+	elif [[ "$(uname -m)" == "i386" || "$(uname -m)" == "i686" ]]; then
+		GVM_ARCH="i386"
 	else
-		GVM_ARCH="386"
+		GVM_ARCH="s390x"
 	fi
 
 	SEMVER=$(extract_version $VERSION)


### PR DESCRIPTION
#372 will be fixed by this. This PR also allows s390x computers to use this. Mac's output arm64 when `uname -m` is run on the M1's, so support for that was added as well.