### PR TITLE
Update old binary base url to current one

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -189,7 +189,7 @@ download_binary() {
 	fi
 	# `GO_BINARY_BASE_URL` env allow user setting base URL for binaries
 	# download, e.g. "https://dl.google.com/go".
-	GO_BINARY_BASE_URL=${GO_BINARY_BASE_URL:-"https://storage.googleapis.com/golang"}
+	GO_BINARY_BASE_URL=${GO_BINARY_BASE_URL:-"https://go.dev/dl"}
 	GO_BINARY_URL="${GO_BINARY_BASE_URL}/${GO_BINARY_FILE}"
 	GO_BINARY_PATH=${GVM_ROOT}/archive/${GO_BINARY_FILE}
 


### PR DESCRIPTION
Current binary base url in master is not used anymore.
Proposed new fallback url is from go.dev as found in the install docs.