### PR TITLE
fixed space in $PATH

### DIFF
--- a/scripts/function/munge_path
+++ b/scripts/function/munge_path
@@ -48,7 +48,7 @@ __gvm_munge_path() {
         return 1
     fi
 
-    IFS=': ' path_in_ary=( $(printf "%s" "${path_in}") ) IFS="$defaultIFS"
+    IFS=':' path_in_ary=( $(printf "%s" "${path_in}") ) IFS="$defaultIFS"
 
     # extract path elements
     local _path


### PR DESCRIPTION
if `/mnt/c/Users/andot/AppData/Local/Programs/Microsoft VS Code/bin` in `$PATH`, it will be spilt to:

`/mnt/c/Users/andot/AppData/Local/Programs/Microsoft`
`VS`
`Code/bin`

This pr fixed this bug.