### PR TITLE
Sorts listed versions correctly

### DIFF
--- a/scripts/list
+++ b/scripts/list
@@ -6,9 +6,9 @@ display_message "gvm gos (installed)"
 echo
 if [[ -d $GVM_ROOT/gos ]]; then
 	if [[ "$gvm_go_name" != "" ]]; then
-		$LS_PATH -1 "$GVM_ROOT/gos" | sed 's/^/   /g' | sed 's/^   '$gvm_go_name\$'/=> '$gvm_go_name'/g'
+		$LS_PATH -1 "$GVM_ROOT/gos" | sort -V | sed 's/^/   /g' | sed 's/^   '$gvm_go_name\$'/=> '$gvm_go_name'/g'
 	else
-		$LS_PATH -1 "$GVM_ROOT/gos" | sed 's/^/   /g'
+		$LS_PATH -1 "$GVM_ROOT/gos" | sort -V | sed 's/^/   /g'
 	fi
 fi
 echo


### PR DESCRIPTION
Sorts the versions listed when executing `gvm list` in order, treating (for example) 1.21.1 as a later version than 1.4, when the different lengths of numbers confuses `ls`'s default sort.