### PR TITLE
Convert `[` to `[[` in `gvm-installer` so that the script can run in zsh

### DIFF
--- a/binscripts/gvm-installer
+++ b/binscripts/gvm-installer
@@ -111,12 +111,12 @@ if [ -z "$GVM_NO_UPDATE_PROFILE" ] ; then
   if [ -f "$HOME/.zshrc" ]; then
     update_profile "$HOME/.zshrc"
   fi
-  if [ "$(uname)" == "Linux" ]; then
+  if [[ "$(uname)" == "Linux" ]]; then
     update_profile "$HOME/.bashrc" || update_profile "$HOME/.bash_profile"
-  elif [ "$(uname)" == "Darwin" ]; then
+  elif [[ "$(uname)" == "Darwin" ]]; then
     LOGIN_SHELL=$(finger $(id -u -n) | grep Shell | cut -d : -f 3)
     echo "macOS detected. User shell is:" $LOGIN_SHELL
-    if [ $LOGIN_SHELL == "/bin/zsh" ]; then 		# macOS moved to ZSH after macOS Catalina
+    if [[ $LOGIN_SHELL == "/bin/zsh" ]]; then 		# macOS moved to ZSH after macOS Catalina
       update_profile "$HOME/.zshrc"
     else
       update_profile "$HOME/.profile" || update_profile "$HOME/.bash_profile"


### PR DESCRIPTION
`[`with `==` operator doesn't work in zsh.
I think the line https://github.com/moovweb/gvm/blob/dd652539fa4b771840846f8319fad303c7d0a8d2/binscripts/gvm-installer#L89 also uses `[[` for the same reason.