### PR TITLE
use a $TAIL_PATH env for 'tail' command

### DIFF
--- a/scripts/env/cd
+++ b/scripts/env/cd
@@ -12,12 +12,12 @@
 if __gvm_is_function __gvm_oldcd; then
     # output from declare -f on zsh omits a newline before opening brace, so
     # we need to add the newline for consistency with bash.
-    eval "$(echo "cd()"; declare -f __gvm_oldcd | sed '1 s/{/\'$'\n''{/' | tail -n +2)"
+    eval "$(echo "cd()"; declare -f __gvm_oldcd | sed '1 s/{/\'$'\n''{/' | $TAIL_PATH -n +2)"
     unset -f __gvm_oldcd
 fi
 
 if __gvm_is_function cd; then
-    eval "$(echo "__gvm_oldcd()"; declare -f cd | sed '1 s/{/\'$'\n''{/' | tail -n +2)"
+    eval "$(echo "__gvm_oldcd()"; declare -f cd | sed '1 s/{/\'$'\n''{/' | $TAIL_PATH -n +2)"
 elif [[ "$(builtin type cd)" == "cd is a shell builtin" ]]; then
     eval "$(echo "__gvm_oldcd() { builtin cd \$*; return \$?; }")"
 fi

--- a/scripts/function/tools
+++ b/scripts/function/tools
@@ -6,6 +6,7 @@ GREP_ERROR="GVM couldn't find grep"
 EGREP_ERROR="GVM couldn't find egrep"
 SORT_ERROR="GVM couldn't find sort"
 HEAD_ERROR="GVM couldn't find head"
+TAIL_ERROR="GVM couldn't find tail"
 HEXDUMP_ERROR="GVM couldn't find hexdump"
 
 LS_PATH=$(unalias ls &> /dev/null; command -v ls) || display_error "$LS_ERROR" || return 1
@@ -15,4 +16,5 @@ GREP_PATH=$(unalias grep &> /dev/null; command -v grep) || display_error "$GREP_
 EGREP_PATH=$(unalias egrep &> /dev/null; command -v egrep) || display_error "$EGREP_ERROR" || return 1
 SORT_PATH=$(unalias sort &> /dev/null; command -v sort) || display_error "$SORT_ERROR" || return 1
 HEAD_PATH=$(unalias head &> /dev/null; command -v head) || display_error "$HEAD_ERROR" || return 1
+TAIL_PATH=$(unalias tail &> /dev/null; command -v tail) || display_error "$TAIL_ERROR" || return 1
 HEXDUMP_PATH=$(unalias hexdump &> /dev/null; command -v hexdump) || display_error "$HEXDUMP_ERROR" || return 1


### PR DESCRIPTION
The command 'tail' was aliased to 'colortail' in my local environment and 'colortail' was not installed locally, so it failed during setting up the 'cd' and '__gvm_oldcd' functions. This caused the 'cd' command to silently do nothing and never change directories.