### PR TITLE
invert if statements that could cause a unexpected short circuits 

### DIFF
--- a/bin/gvm
+++ b/bin/gvm
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-[ -n "$GVM_DEBUG" ] && {
+[ -z "$GVM_DEBUG" ] || {
   set -x
 }
 

--- a/binscripts/gvm-installer
+++ b/binscripts/gvm-installer
@@ -57,15 +57,15 @@ GVM_DEST=${2:-$HOME}
 GVM_NAME="gvm"
 SRC_REPO=${SRC_REPO:-https://github.com/moovweb/gvm.git}
 
-[ "$GVM_DEST" = "$HOME" ] && GVM_NAME=".gvm"
+[ "$GVM_DEST" != "$HOME" ] || GVM_NAME=".gvm"
 
-[ -d "$GVM_DEST/$GVM_NAME" ] && display_error \
+[ ! -d "$GVM_DEST/$GVM_NAME" ] || display_error \
     "Already installed! Remove old installation by running
 
     rm -rf $GVM_DEST/$GVM_NAME"
 
 [ -d "$GVM_DEST" ] || mkdir -p "$GVM_DEST" > /dev/null 2>&1 || display_error "Failed to create $GVM_DEST"
-[ -z "$(which git)" ] && display_error "Could not find git
+[ -n "$(which git)" ] || display_error "Could not find git
 
   debian/ubuntu: apt-get install git
   redhat/centos: yum install git
@@ -102,7 +102,7 @@ builtin cd "$GVM_DEST/$GVM_NAME" && git checkout --quiet "$BRANCH" 2> /dev/null 
 
 popd > /dev/null
 
-[ -z "$GVM_NO_GIT_BAK" ] && mv "$GVM_DEST/$GVM_NAME/.git" "$GVM_DEST/$GVM_NAME/git.bak"
+[ -n "$GVM_NO_GIT_BAK" ] || mv "$GVM_DEST/$GVM_NAME/.git" "$GVM_DEST/$GVM_NAME/git.bak"
 
 source_line="[[ -s \"${GVM_DEST}/$GVM_NAME/scripts/gvm\" ]] && source \"${GVM_DEST}/$GVM_NAME/scripts/gvm\""
 source_file="${GVM_DEST}/$GVM_NAME/scripts/gvm"
@@ -136,7 +136,7 @@ fi
 echo "export GVM_ROOT=$GVM_DEST/$GVM_NAME" > "$GVM_DEST/$GVM_NAME/scripts/gvm"
 echo ". \$GVM_ROOT/scripts/gvm-default" >> "$GVM_DEST/$GVM_NAME/scripts/gvm"
 check_existing_go
-[[ -s "$GVM_DEST/$GVM_NAME/scripts/gvm" ]] && source "$GVM_DEST/$GVM_NAME/scripts/gvm"
+[[ ! -s "$GVM_DEST/$GVM_NAME/scripts/gvm" ]] || source "$GVM_DEST/$GVM_NAME/scripts/gvm"
 echo "Installed GVM v${GVM_VERSION}"
 echo
 echo "Please restart your terminal session or to get started right away run"

--- a/scripts/cross
+++ b/scripts/cross
@@ -22,7 +22,7 @@ display_list() {
 
 command -v go &> /dev/null || display_fatal "Only available in versions after Go 1"
 
-[ -z "$1" ] && display_list
+[ -n "$1" ] || display_list
 
 if [ ! -f "$GOROOT/pkg/tool/cross" ]; then
 	display_message "Installing x86, x86-64, and ARM commands"
@@ -38,7 +38,7 @@ fi
 
 export GOOS=$1
 shift
-[ -z "$1" ] && display_usage && display_fatal "arch is not specified"
+[ -n "$1" ] || display_usage && display_fatal "arch is not specified"
 export GOARCH=$1
 
 if [ ! -d "$GOROOT/pkg/${GOOS}_${GOARCH}" ]; then

--- a/scripts/env/cd
+++ b/scripts/env/cd
@@ -60,30 +60,30 @@ cd() {
 	fi
 
     # gather default environment settings, they can change at any time!
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "Resolving defaults..."
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "Resolving defaults..."
     defaults_hash=( $(__gvm_read_environment_file "${GVM_ROOT}/environments/default") )
     if [[ $? -eq 0 ]]; then
         defaults_resolved=true
     else
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "Can't find default environment. Falling back to system."
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "Can't find default environment. Falling back to system."
         defaults_hash=( $(__gvm_read_environment_file "${GVM_ROOT}/environments/system") )
         if [[ $? -eq 0 ]]; then
             defaults_resolved=true
         else
-            [[ "${GVM_DEBUG}" -eq 1 ]] && echo "Can't find system environment."
+            [[ "${GVM_DEBUG}" -ne 1 ]] || echo "Can't find system environment."
         fi
     fi
 
     if [[ "${defaults_resolved}" == false ]]; then
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "Resolving fallback go version and pkgset from all available."
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "Resolving fallback go version and pkgset from all available."
         local fallback_go_version="$(__gvm_resolve_fallback_version)"
         local fallback_go_pkgset="$(__gvm_resolve_fallback_pkgset "${fallback_go_version}")"
 
 
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "======================================="
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "fallback_go_version => $fallback_go_version"
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "fallback_go_pkgset => $fallback_go_pkgset"
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "======================================="
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "======================================="
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "fallback_go_version => $fallback_go_version"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "fallback_go_pkgset => $fallback_go_pkgset"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "======================================="
 
         defaults_hash=( $(setValueForKeyFakeAssocArray "gvm_go_name" "${fallback_go_version}" "${defaults_hash[*]}") )
         defaults_hash=( $(setValueForKeyFakeAssocArray "gvm_pkgset_name" "${fallback_go_pkgset}" "${defaults_hash[*]}") )
@@ -96,10 +96,10 @@ cd() {
     defaults_go_pkgset="$(valueForKeyFakeAssocArray "gvm_pkgset_name" "${defaults_hash[*]}")"
 
 
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "defaults_go_name => $defaults_go_name"
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "defaults_go_pkgset => $defaults_go_pkgset"
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "defaults_go_name => $defaults_go_name"
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "defaults_go_pkgset => $defaults_go_pkgset"
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 
     if [[ "${GVM_DEBUG}" -eq 1 ]]; then
         echo "Resolved default go: ${defaults_go_name:-[EMPTY]}"
@@ -109,19 +109,19 @@ cd() {
     dot_go_version="$(__gvmp_find_closest_dot_go_version)"
     rslt=$?
 
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "---------------------------------------"
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "dot_go_version => $dot_go_version"
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "defaults_go_name => $defaults_go_name"
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "---------------------------------------"
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "---------------------------------------"
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "dot_go_version => $dot_go_version"
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "defaults_go_name => $defaults_go_name"
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "---------------------------------------"
 
     if [[ $rslt -eq 0 ]]; then
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "Found dot_go_version: ${dot_go_version}"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "Found dot_go_version: ${dot_go_version}"
         local use_goversion="$(__gvmp_read_dot_go_version "${dot_go_version}")"
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "Switching to: ${use_goversion}"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "Switching to: ${use_goversion}"
         gvm use "${use_goversion}" || return 1
         unset use_goversion
     elif [[ -n "${defaults_go_name}" ]]; then
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "No .go-version found. Using system or default go."
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "No .go-version found. Using system or default go."
         # gvm use --quiet "${defaults_go_name}" || return 1
         # gvm use "${defaults_go_name}" || return 1
     else
@@ -139,22 +139,22 @@ cd() {
 
     dot_go_pkgset="$(__gvmp_find_closest_dot_go_pkgset)"
     rslt=$?
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "--------------------------------"
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "dot_go_pkgset => $dot_go_pkgset"
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "--------------------------------"
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "--------------------------------"
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "dot_go_pkgset => $dot_go_pkgset"
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "--------------------------------"
     if [[ $rslt -eq 0 ]]; then
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "Found .go-pkgset: ${dot_go_pkgset}"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "Found .go-pkgset: ${dot_go_pkgset}"
         local use_gopkgset="$(__gvmp_read_dot_go_pkgset "${dot_go_pkgset}")"
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "Switching to: ${use_gopkgset}"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "Switching to: ${use_gopkgset}"
         gvm pkgset use "${use_gopkgset}" || return 1
         unset use_gopkgset
     elif [[ -n "${defaults_go_pkgset}" ]];then
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "No .go-pkgset found. Using system or default pkgset."
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "----------    defaults_go_pkgset => $defaults_go_pkgset     ----------"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "No .go-pkgset found. Using system or default pkgset."
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "----------    defaults_go_pkgset => $defaults_go_pkgset     ----------"
         # gvm pkgset use --quiet "${defaults_go_pkgset}" || return 1
     else
         # quietly failing
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "No fallback pkgset could be found."
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "No fallback pkgset could be found."
     fi
 
     return 0
@@ -185,7 +185,7 @@ __gvmp_read_dot_go_version() {
 
     while IFS=$'\n' read -r _line; do
         # skip comment lines
-        [[ "${_line}" =~ \#.* ]] && continue
+        [[ ! "${_line}" =~ \#.* ]] || continue
 
         # looking for pattern "go1.2[.3]"
         if [[ "${_line}" =~ ${regex} ]]; then
@@ -211,7 +211,7 @@ __gvmp_read_dot_go_pkgset() {
 
     while IFS=$'\n' read -r _line; do
         # skip comment lines
-        [[ "${_line}" =~ \#.* ]] && continue
+        [[ ! "${_line}" =~ \#.* ]] || continue
 
         # fairly loose naming convention, exclude @ symbol
         if [[ "${_line}" =~ ${regex} ]]; then

--- a/scripts/env/pkgset-use
+++ b/scripts/env/pkgset-use
@@ -51,21 +51,21 @@ gvm_pkgset_use() {
     local local_pkgset_regex="^(\/[^:\\\n\\\0]*)+$"
     local pkgset_rematch local_pkgset_rematch
 
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "gvm_pkgset_use: \$@   => $@"
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "gvm_pkgset_use: \$@   => $@"
     for _option in "${@}"; do
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "Parsing ${FUNCNAME[0]}() argument: ${_option:-[EMPTY]}"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "Parsing ${FUNCNAME[0]}() argument: ${_option:-[EMPTY]}"
 
         # if the accumulator has a trailing option flag (that is, the option
         # flag has been specified but no argument has been supplied) then make
         # sure the next _option value is not another option flag.
         if [[ $(( ${#accumulator[@]}%2 )) -eq 1 && "${_option}" =~ ^[\-]+ ]]; then
-            [[ "${GVM_DEBUG}" -eq 1 ]] && echo "Missing argument for: '${accumulator[${#accumulator[@]}-1]}'"
+            [[ "${GVM_DEBUG}" -ne 1 ]] || echo "Missing argument for: '${accumulator[${#accumulator[@]}-1]}'"
             return 1
         fi
 
         # scan pkgset_rematch checks exactly once each time through
         pkgset_rematch=false
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "_option: ${_option}, pkgset_regex: ${pkgset_regex}"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "_option: ${_option}, pkgset_regex: ${pkgset_regex}"
         if __gvm_rematch "${_option}" "${pkgset_regex}"; then
             pkgset_rematch=true
         fi
@@ -80,9 +80,9 @@ gvm_pkgset_use() {
         if [[ "${pkgset_rematch}" == true ]] && [[ $(( ${#accumulator[@]}%2 )) -eq 0 ]]; then
             # if the regex matches and the accumulator is even, we can add the
             # key/val pair.
-            [[ "${GVM_DEBUG}" -eq 1 ]] && echo "========================"
-            [[ "${GVM_DEBUG}" -eq 1 ]] && echo "GVM_REMATCH => $GVM_REMATCH"
-            [[ "${GVM_DEBUG}" -eq 1 ]] && echo "========================"
+            [[ "${GVM_DEBUG}" -ne 1 ]] || echo "========================"
+            [[ "${GVM_DEBUG}" -ne 1 ]] || echo "GVM_REMATCH => $GVM_REMATCH"
+            [[ "${GVM_DEBUG}" -ne 1 ]] || echo "========================"
             accumulator+=( "--pkgset" "${GVM_REMATCH[1]}" )
         elif [[ "${pkgset_rematch}" == true ]] && [[ ${#accumulator[@]} -gt 0 && "${accumulator[${#accumulator[@]}-1]}" == "--pkgset" ]]; then
             # if the regex matches and the accumulator is odd, the previous
@@ -169,9 +169,9 @@ gvm_pkgset_use() {
 
     [[ -n "$gvm_go_name" ]] || display_error "No Go version selected" || return 1
 
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "++++++++"
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "options_hash => ${options_hash[*]}"
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "++++++++"
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "++++++++"
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "options_hash => ${options_hash[*]}"
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "++++++++"
 
     if [[ -n "$(valueForKeyFakeAssocArray "--local" "${options_hash[*]}")" ]]; then
         local local_pkgset="$(valueForKeyFakeAssocArray "--local" "${options_hash[*]}")"
@@ -186,7 +186,7 @@ gvm_pkgset_use() {
             display_error "Cannot find local package set" || return 1
 
         local_pkgset="${local_pkgset}/.gvm_local"
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "Resolved local directory: ${local_pkgset}"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "Resolved local directory: ${local_pkgset}"
 
         fuzzy_match=$($LS_PATH -1 "$local_pkgset/environments" | $SORT_PATH | $GREP_PATH "$gvm_go_name@" | $GREP_PATH "local" | $HEAD_PATH -n 1)
         [[ -n "${fuzzy_match}" ]] || display_error "Cannot find local package set" || return 1
@@ -202,7 +202,7 @@ gvm_pkgset_use() {
 
         # fix PATH to correct order
         local fixed_path="$(__gvm_munge_path)"
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "Original path: $PATH" && echo "Munged path: ${fixed_path}"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "Original path: $PATH" && echo "Munged path: ${fixed_path}"
         export PATH="${fixed_path}"
         unset fixed_path
 
@@ -215,18 +215,18 @@ gvm_pkgset_use() {
     elif [[ -n "$(valueForKeyFakeAssocArray "--pkgset" "${options_hash[*]}")" ]]; then
         local pkgset="$(valueForKeyFakeAssocArray "--pkgset" "${options_hash[*]}")"
 
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "=================="
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "gvm_go_name => $gvm_go_name"
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "pkgset => $pkgset"
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "=================="
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "=================="
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "gvm_go_name => $gvm_go_name"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "pkgset => $pkgset"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "=================="
 
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "$LS_PATH -1 "$GVM_ROOT/environments" | $SORT_PATH | $GREP_PATH "$gvm_go_name@" | $GREP_PATH "${pkgset}" | $HEAD_PATH -n 1"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "$LS_PATH -1 "$GVM_ROOT/environments" | $SORT_PATH | $GREP_PATH "$gvm_go_name@" | $GREP_PATH "${pkgset}" | $HEAD_PATH -n 1"
         fuzzy_match=$($LS_PATH -1 "$GVM_ROOT/environments" | $SORT_PATH | $GREP_PATH "$gvm_go_name@" | $GREP_PATH "${pkgset}" | $HEAD_PATH -n 1)
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "fuzzy_match => $fuzzy_match"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "fuzzy_match => $fuzzy_match"
         # [[ -n "${fuzzy_match}" ]] || display_error "Invalid package set: ${pkgset}" || return 1
         if [[ -z "${fuzzy_match}" ]]; then
             gvm use --quiet $gvm_go_name
-            [[ "${GVM_DEBUG}" -eq 1 ]] && echo ">>>>>>>>   gvm pkgset create $pkgset   <<<<<<<"
+            [[ "${GVM_DEBUG}" -ne 1 ]] || echo ">>>>>>>>   gvm pkgset create $pkgset   <<<<<<<"
             gvm pkgset create $pkgset
             gvm pkgset use --quiet $pkgset
         fi
@@ -237,13 +237,13 @@ gvm_pkgset_use() {
 
         # fix PATH to correct order
         local fixed_path="$(__gvm_munge_path)"
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "Original path: $PATH" && echo "Munged path: ${fixed_path}"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "Original path: $PATH" && echo "Munged path: ${fixed_path}"
         export PATH="${fixed_path}"
         unset fixed_path
 
         if [[ -n "$(valueForKeyFakeAssocArray "--default" "${options_hash[*]}")" ]]; then
             cp "$GVM_ROOT/environments/$fuzzy_match" "$GVM_ROOT/environments/default"
-            [[ $? -ne 0 ]] && display_error "Couldn't make $fuzzy_match default"
+            [[ $? -eq 0 ]] || display_error "Couldn't make $fuzzy_match default"
         fi
 
         if [[ -z "$(valueForKeyFakeAssocArray "--quiet" "${options_hash[*]}")" ]]; then

--- a/scripts/env/use
+++ b/scripts/env/use
@@ -72,7 +72,7 @@ gvm_use() {
 
     for _option in "${@}"
     do
-        [[ "${GVM_DEBUG}" -eq 1 ]] && echo "Parsing ${FUNCNAME[0]}() argument: ${_option:-[EMPTY]}"
+        [[ "${GVM_DEBUG}" -ne 1 ]] || echo "Parsing ${FUNCNAME[0]}() argument: ${_option:-[EMPTY]}"
 
         # if the accumulator has a trailing option flag (that is, the option
         # flag has been specified but no argument has been supplied) then make
@@ -220,14 +220,14 @@ gvm_use() {
 
     # fix PATH to correct order
     local fixed_path="$(__gvm_munge_path)"
-    [[ "${GVM_DEBUG}" -eq 1 ]] && echo "Original path: $PATH" && echo "Munged path: ${fixed_path}"
+    [[ "${GVM_DEBUG}" -ne 1 ]] || echo "Original path: $PATH" && echo "Munged path: ${fixed_path}"
     export PATH="${fixed_path}"
     unset fixed_path
 
     if [[ -n "$(valueForKeyFakeAssocArray "--default" "${options_hash[*]}")" ]]
     then
         cp "$GVM_ROOT/environments/$fuzzy_match" "$GVM_ROOT/environments/default"
-        [[ $? -ne 0 ]] && display_error "Couldn't make $fuzzy_match default"
+        [[ $? -eq 0 ]] || display_error "Couldn't make $fuzzy_match default"
     fi
 
     local pkgset="$(valueForKeyFakeAssocArray "--pkgset" "${options_hash[*]}")"

--- a/scripts/function/_bash_pseudo_hash
+++ b/scripts/function/_bash_pseudo_hash
@@ -76,7 +76,7 @@ setValueForKeyFakeAssocArray() {
     unset i _target_ary_length
 
     # key not found, append
-    [[ "${found}" == false ]] && target_ary+=( "${target_key}:${_encoded_new_value}" )
+    [[ "${found}" != false ]] || target_ary+=( "${target_key}:${_encoded_new_value}" )
 
     printf "%s" "${target_ary[*]}"
 

--- a/scripts/function/_shell_compat
+++ b/scripts/function/_shell_compat
@@ -4,7 +4,7 @@
 [[ ${GVM_SHELL_COMPAT:-} -eq 1 ]] && return || readonly GVM_SHELL_COMPAT=1
 
 # force zsh to start arrays at index 0
-# [[ -n $ZSH_VERSION ]] && setopt KSH_ARRAYS
+# [[ -z $ZSH_VERSION ]] || setopt KSH_ARRAYS
 
 # __gvm_is_function()
 # /*!
@@ -16,7 +16,7 @@
 __gvm_is_function() {
     local func_name="${1}"
 
-    [[ "x${func_name}" == "x" ]] && return 1
+    [[ "x${func_name}" != "x" ]] || return 1
 
     # using 'declare -f' is the most reliable way for both bash and zsh!
     builtin declare -f "${1}" >/dev/null

--- a/scripts/function/locale_text
+++ b/scripts/function/locale_text
@@ -32,17 +32,20 @@ locale_text_for_key() {
     local text_path="${GVM_ROOT}/locales"
     local text_key_path="${text_path}/${text_locale}_${text_key}.txt"
 
-    [[ "x${text_key}" == "x" || ! -r "${text_key_path}" ]] && echo "" && return 1
+    if [[ "x${text_key}" == "x" || ! -r "${text_key_path}" ]]; then
+        echo ""
+        return 1
+    fi
 
     local line_count=0
     local text=""
     while IFS= read -r _line; do
         (( line_count++ ))
-        [[ "${line_count}" -gt 10 ]] && break
+        [[ "${line_count}" -lt 11 ]] || break
         text+="${_line}"$'\n'
     done <<< "$(cat "${text_key_path}")"
 
-    [[ -z "${line_count// }" ]] && text=""
+    [[ -n "${line_count// }" ]] || text=""
 
     echo "${text}"
 

--- a/scripts/function/munge_path
+++ b/scripts/function/munge_path
@@ -78,11 +78,11 @@ __gvm_munge_path() {
         for (( i=0; i<${#path_out_ary[@]}; i++ ))
         do
             local __element="${path_out_ary[i]}"
-            [[ -n "${__element}" ]] && _dedupe_path_out_ary+=( "${__element}" )
+            [[ -z "${__element}" ]] || _dedupe_path_out_ary+=( "${__element}" )
             # reset duplicates to an empty string so we can ignore them
             for (( j=${#path_out_ary[@]}-1; j>i; j-- ))
             do
-                [[ "${__element}" == "${path_out_ary[j]}" ]] && path_out_ary[j]=""
+                [[ "${__element}" != "${path_out_ary[j]}" ]] || path_out_ary[j]=""
             done
             unset __element
         done

--- a/scripts/function/read_environment_file
+++ b/scripts/function/read_environment_file
@@ -45,7 +45,7 @@ __gvm_read_environment_file() {
     while IFS=$'\n' read -r _line; do
         local __key __val
         # skip comment lines
-        [[ "${_line}" =~ \#.* ]] && continue
+        [[ ! "${_line}" =~ \#.* ]] || continue
 
         # each parseable line follows this format:
         #   export VAR; VAR="VALUE"

--- a/scripts/function/resolve_fallback_pkgset
+++ b/scripts/function/resolve_fallback_pkgset
@@ -25,7 +25,10 @@ __gvm_resolve_fallback_pkgset() {
     local local_pkgset_regex='^([[:space:]]*[=>*]*)(L[[:space:]]+)(\/[^:\\\n\\\0]*)+$'
     local goversion_regex='^([[:space:]]*[=>*]*)(G[[:space:]]+)(go([0-9]+(\.[0-9]+)*))$'
 
-    [[ "x${version}" == "x" ]] && echo "" && return 1
+    if [[ "x${version}" == "x" ]]; then
+        echo ""
+        return 1
+    fi
 
     while IFS=$'\n' read -r _line; do
         # skip the G (go version) line

--- a/scripts/gvm-default
+++ b/scripts/gvm-default
@@ -16,7 +16,7 @@ mkdir -p "$GVM_ROOT/environments" > /dev/null 2>&1
 export GVM_VERSION=$(cat "$GVM_ROOT/VERSION")
 export PATH="$GVM_ROOT/bin:$PATH"
 export GVM_PATH_BACKUP="$PATH"
-[ -f "$GVM_ROOT/environments/default" ] && . "$GVM_ROOT/environments/default"
+[ ! -f "$GVM_ROOT/environments/default" ] || . "$GVM_ROOT/environments/default"
 . "$GVM_ROOT/scripts/env/gvm"
 
 . "$GVM_ROOT/scripts/env/cd" && cd .

--- a/scripts/install
+++ b/scripts/install
@@ -57,7 +57,7 @@ read_command_line() {
 
 download_source() {
 	GO_CACHE_PATH=$GVM_ROOT/archive/go
-	[[ -d $GO_CACHE_PATH ]] && return
+	[[ ! -d $GO_CACHE_PATH ]] || return
 	display_message "Downloading Go source..."
 	git clone "$GO_SOURCE_URL" "$GO_CACHE_PATH" >> "$GVM_ROOT/logs/go-download.log"  2>&1 ||
 		display_fatal "Couldn't download Go source. Check the logs $GVM_ROOT/logs/go-download.log"
@@ -90,7 +90,7 @@ compile_go() {
 		MAKE_SCRIPT=make.bash
 		;;
 	esac
-	[ -z "$GOROOT_BOOTSTRAP" ] && export GOROOT_BOOTSTRAP=$(go env GOROOT) 
+	[ -n "$GOROOT_BOOTSTRAP" ] || export GOROOT_BOOTSTRAP=$(go env GOROOT) 
 	unset GOARCH && unset GOOS && unset GOPATH && unset GOBIN && unset GOROOT &&
 	export GOBIN=$GO_INSTALL_ROOT/bin &&
 	export PATH=$GOBIN:$PATH &&
@@ -327,7 +327,7 @@ install_from_source() {
 main() {
 	trap 'display_fatal "Canceled!"' INT
 	read_command_line "$@"
-	[[ "$VERSION" == "" ]] && display_fatal "No version specified"
+	[[ "$VERSION" != "" ]] || display_fatal "No version specified"
 
 	if [[ "$GO_NAME" == "" ]]; then
 		GO_NAME=$VERSION

--- a/scripts/pkgset-list
+++ b/scripts/pkgset-list
@@ -16,7 +16,7 @@ if [[ -d $GVM_ROOT/pkgsets/$gvm_go_name ]]; then
 	fi
 
 	for cur_dir in $GVM_ROOT/pkgsets/$gvm_go_name/*; do
-		[[ "$cur_dir" == "$GVM_ROOT/pkgsets/$gvm_go_name/*" ]] && exit
+		[[ "$cur_dir" != "$GVM_ROOT/pkgsets/$gvm_go_name/*" ]] || exit
     pkgset=$(basename "$cur_dir")
 		if [[ "$gvm_pkgset_name" == "$pkgset" ]]; then
 			echo "=>  $pkgset"

--- a/scripts/uninstall
+++ b/scripts/uninstall
@@ -2,7 +2,7 @@
 
 . "$GVM_ROOT/scripts/functions"
 
-[[ "$1" == "" ]] &&
+[[ "$1" != "" ]] ||
 	display_fatal "Please specify the version"
 
 fuzzy_match=$($LS_PATH -1 "$GVM_ROOT/gos" | $SORT_PATH | $GREP_PATH "$1" | $HEAD_PATH -n 1 | $GREP_PATH "$1") ||


### PR DESCRIPTION
If the code is running in a shell or non interactive environment with `set -eo pipefail` called previously then one-line shorthand-form if statements that have no false path handle will bubble an error up immediately. Much of the code does not expect for this flag to be set.

I scrubbed through the scripts pretty quick and used [De Morgans' law](https://en.wikipedia.org/wiki/De_Morgan%27s_laws) to adjust them.

I'm pretty sure the main issue my installer is having is around "./scripts/gvm-default" specifically when running `source "$HOME/.gvm/scripts/gvm"` if this looks too dense.


I also left lines like `[[ -s "$HOME/.gvm/scripts/gvm" ]] && source "$HOME/.gvm/scripts/gvm"` alone because it's technically a line present on people's rc files and pattern matching that is performed would need to be adjusted.



Thanks for your consideration.