### PR TITLE
go 1.22 now requires go 1.20.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ gvm install go1.20.7
 
 #### To install Go 1.20+
 Go 1.20+ requires go1.17.3+. Use the below:
-
+Go 1.22+ requires go 1.20.6
 ```
 gvm install go1.4 -B
 gvm use go1.4
@@ -95,8 +95,11 @@ export GOROOT_BOOTSTRAP=$GOROOT
 gvm install go1.17.13
 gvm use go1.17.13
 export GOROOT_BOOTSTRAP=$GOROOT
-gvm install go1.20
-gvm use go1.20
+gvm install go1.20.6
+gvm use go1.20.6
+export GOROOT_BOOTSTRAP=$GOROOT
+gvm install go1.22
+gvm use go1.22
 ```
 
 [compiler_note]: https://docs.google.com/document/d/1OaatvGhEAq7VseQ9kkavxKNAfepWy2yhPUBs96FGV28/edit


### PR DESCRIPTION
go 1.22+ now requires go 1.20.6 to compile so it's reflected in readme