### PR TITLE
Fix path handling in cd

### DIFF
--- a/scripts/env/cd
+++ b/scripts/env/cd
@@ -19,7 +19,7 @@ fi
 if __gvm_is_function cd; then
     eval "$(echo "__gvm_oldcd()"; declare -f cd | sed '1 s/{/\'$'\n''{/' | tail -n +2)"
 elif [[ "$(builtin type cd)" == "cd is a shell builtin" ]]; then
-    eval "$(echo "__gvm_oldcd() { builtin cd \$*; return \$?; }")"
+    eval "$(echo "__gvm_oldcd() { builtin cd \"\$@\"; return \$?; }")"
 fi
 
 # Path cleanup
@@ -46,7 +46,7 @@ export PATH="$(__gvm_munge_path)"
 cd() {
     # @FIXME: gvm_oldcd is broken on re-sourcing .bashrc!
     if __gvm_is_function __gvm_oldcd; then
-        __gvm_oldcd $*
+        __gvm_oldcd "$@"
     fi
 
     local dot_go_version dot_go_pkgset rslt


### PR DESCRIPTION
The use of `$*` prevents correctly cd'ing into a directory with spaces in its path name since each segment of the name around the space is treated as if it is a separate argument. 

Example:
`"dir/path with spaces"` is treated as `dir/path` and `with` and `spaces`. This causes `cd` to fail. It also causes `__gvm_oldcd` to fail, although call to `builtin cd` will succeed.

Same issue happens if path is specified as `dir/path\ with\ spaces`. 

This patch fixes this issue by using "$@" to correctly handle spaces.

Fixes #457 