### PR TITLE
Don't break paths on space while fixing for rvm

### DIFF
--- a/scripts/function/munge_path
+++ b/scripts/function/munge_path
@@ -48,7 +48,7 @@ __gvm_munge_path() {
         return 1
     fi
 
-    IFS=': ' path_in_ary=( $(printf "%s" "${path_in}") ) IFS="$defaultIFS"
+    IFS=':' path_in_ary=( $(printf "%s" "${path_in}") ) IFS="$defaultIFS"
 
     # extract path elements
     local _path


### PR DESCRIPTION
I was running GVM in my WSL installation, which has many paths contains space like:
/mnt/c/Program Files/Microsoft SQL Server/Client SDK..

When this script would run on startup, it would mess up these paths as it splits on both ":" and " "

In general, space is not a special char in bash paths, so we should not split on it. Seems to be a typo.