### PR TITLE
Update the cd script to work with directory names that include spaces

### DIFF
--- a/scripts/env/cd
+++ b/scripts/env/cd
@@ -19,7 +19,7 @@ fi
 if __gvm_is_function cd; then
     eval "$(echo "__gvm_oldcd()"; declare -f cd | sed '1 s/{/\'$'\n''{/' | tail -n +2)"
 elif [[ "$(builtin type cd)" == "cd is a shell builtin" ]]; then
-    eval "$(echo "__gvm_oldcd() { builtin cd \$*; return \$?; }")"
+    eval "$(echo "__gvm_oldcd() { if [[ -z \"\$*\" ]]; then builtin cd; return \$?; else builtin cd \"\$*\"; return \$?; fi }")"
 fi
 
 # Path cleanup


### PR DESCRIPTION
This patch adds (escaped) quotation marks around the directory argument to the builtin cd so that the user can cd into a directory with spaces in it