### PR TITLE
Fix `cd` command hook bug and add an option to disable it

### DIFF
--- a/scripts/env/cd
+++ b/scripts/env/cd
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# To disable this cd hook and prevent potential slowdowns, set GVM_DISABLE_CD_HOOK to a non-empty string.
+[ -n "$GVM_DISABLE_CD_HOOK" ] && return
+
 # Override the cd() function to implement auto-switching of go version and
 # pkgset when changing into a directory.
 

--- a/scripts/env/cd
+++ b/scripts/env/cd
@@ -19,7 +19,7 @@ fi
 if __gvm_is_function cd; then
     eval "$(echo "__gvm_oldcd()"; declare -f cd | sed '1 s/{/\'$'\n''{/' | tail -n +2)"
 elif [[ "$(builtin type cd)" == "cd is a shell builtin" ]]; then
-    eval "$(echo "__gvm_oldcd() { builtin cd \$*; return \$?; }")"
+    eval "$(echo "__gvm_oldcd() { builtin cd \"\$@\"; return \$?; }")"
 fi
 
 # Path cleanup
@@ -46,7 +46,7 @@ export PATH="$(__gvm_munge_path)"
 cd() {
     # @FIXME: gvm_oldcd is broken on re-sourcing .bashrc!
     if __gvm_is_function __gvm_oldcd; then
-        __gvm_oldcd $*
+        __gvm_oldcd "$@"
     fi
 
     local dot_go_version dot_go_pkgset rslt


### PR DESCRIPTION
I have been bothered by the "-bash: cd: too many arguments" error for a while and just discovered the cause.

Additionally, the `cd` command hook is causing notable slowdowns. Please ensure future PRs are reviewed thoroughly to avoid such issues.

ref: https://unix.stackexchange.com/questions/41571/what-is-the-difference-between-and#94135