### PR TITLE
Fix incorrect path reformatting issue

### DIFF
--- a/scripts/function/munge_path
+++ b/scripts/function/munge_path
@@ -48,7 +48,7 @@ __gvm_munge_path() {
         return 1
     fi
 
-    IFS=': ' path_in_ary=( $(printf "%s" "${path_in}") ) IFS="$defaultIFS"
+    IFS=': ' path_in_ary=( "$(printf "%s" "${path_in}")" ) IFS="$defaultIFS"
 
     # extract path elements
     local _path
@@ -57,19 +57,19 @@ __gvm_munge_path() {
         if [[ "${_path}" =~ $gvm_regex ]]
         then
             # echo "matched (gvm): ${_path}"
-            gvm_ary+=(${_path})
+            gvm_ary+=("${_path}")
         elif [[ "${_path}" =~ $rvm_regex ]]
         then
             # echo "matched (rvm): ${_path}"
-            rvm_ary+=(${_path})
+            rvm_ary+=("${_path}")
         else
-            general_ary+=(${_path})
+            general_ary+=("${_path}")
         fi
     done
     unset _path
 
     # assemble path array
-    path_out_ary=( ${rvm_ary[@]} ${gvm_ary[@]} ${general_ary[@]} )
+    path_out_ary=( "${rvm_ary[@]}" "${gvm_ary[@]}" "${general_ary[@]}" )
 
     # deduplicate path_out_ary if requested, do this just to be helpful :)
     if [[ "${path_dedupe_flag}" == true ]]
@@ -86,7 +86,7 @@ __gvm_munge_path() {
             done
             unset __element
         done
-        path_out_ary=( ${_dedupe_path_out_ary[@]} )
+        path_out_ary=( "${_dedupe_path_out_ary[@]}" )
         unset _dedupe_path_out_ary
     fi
 


### PR DESCRIPTION
I have fixed an issue in the `__gvm_munge_path()` function located in the `~/.gvm/scripts/function/munge_path` file. Previously, paths containing spaces were being incorrectly parsed, leading to problems such as `/AppData/Local/Programs/Microsoft:VS:Code/bin:/snap/bin`, where colons (:) were inserted into the path names.

Because of this, after installing `gvm`, some terminal commands would result in a "command not found" error.

To resolve this, I updated the script to enclose each path in double quotes (`""`) when adding them to the array. This ensures paths with spaces are handled correctly.

This fix should solve the following issues: https://github.com/moovweb/gvm/issues/486#issue-2433874341, https://github.com/moovweb/gvm/issues/487#issue-2444729848, https://github.com/moovweb/gvm/issues/466#issue-2165852612