### PR TITLE
fix: handle optional 'go' prefix in parsed Go version strings

### DIFF
--- a/scripts/env/cd
+++ b/scripts/env/cd
@@ -181,15 +181,15 @@ __gvmp_find_closest_dot_go_pkgset() {
 __gvmp_read_dot_go_version() {
     local filepath="${1}"
     local version=""
-    local regex='^(go([0-9]+(\.[0-9]+)*))$'
+    local regex='^((go)?([0-9]+(\.[0-9]+)*))$'
 
     while IFS=$'\n' read -r _line; do
         # skip comment lines
         [[ "${_line}" =~ \#.* ]] && continue
 
-        # looking for pattern "go1.2[.3]"
+        # looking for pattern "[go]1.2[.3]"
         if [[ "${_line}" =~ ${regex} ]]; then
-            version="${_line}"
+            version="go${_line#go}"
             break
         fi
     done <<< "$(cat "${filepath}")"


### PR DESCRIPTION
Compatible with https://github.com/kubernetes/kubernetes/blob/master/.go-version

Fixes #477
Repeat #497 , but that PR doesn't seem to have been updated in a long time