### PR TITLE
Quote path parts when munging

### DIFF
--- a/scripts/function/munge_path
+++ b/scripts/function/munge_path
@@ -48,7 +48,7 @@ __gvm_munge_path() {
         return 1
     fi
 
-    IFS=': ' path_in_ary=( $(printf "%s" "${path_in}") ) IFS="$defaultIFS"
+    IFS=':' path_in_ary=( $(printf "%s" "${path_in}") ) IFS="$defaultIFS"
 
     # extract path elements
     local _path
@@ -63,13 +63,13 @@ __gvm_munge_path() {
             # echo "matched (rvm): ${_path}"
             rvm_ary+=(${_path})
         else
-            general_ary+=(${_path})
+            general_ary+=("${_path}")
         fi
     done
     unset _path
 
     # assemble path array
-    path_out_ary=( ${rvm_ary[@]} ${gvm_ary[@]} ${general_ary[@]} )
+    path_out_ary=( ${rvm_ary[@]} ${gvm_ary[@]} "${general_ary[@]}" )
 
     # deduplicate path_out_ary if requested, do this just to be helpful :)
     if [[ "${path_dedupe_flag}" == true ]]
@@ -86,7 +86,7 @@ __gvm_munge_path() {
             done
             unset __element
         done
-        path_out_ary=( ${_dedupe_path_out_ary[@]} )
+        path_out_ary=( "${_dedupe_path_out_ary[@]}" )
         unset _dedupe_path_out_ary
     fi
 


### PR DESCRIPTION
This seems to correct the issue (at least on WSL2 instances) that have a directory in the `$PATH` variable that has spaces in it.  Specifically, I was testing this using the `code .` command once `gvm` had been loaded and it seems to work as expected.

I'm not sure if there are other test cases I should be worried about, but this seems to solve the issue in #515 